### PR TITLE
PyPI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,18 @@ env:
   matrix:
   - TEST_DOC=false
   - TEST_DOC=true
+notifications:
+  email: false
+  slack:
+    rooms:
+    - secure: R8rDp7cXw0h40KKgUSg/VlZsf8y5FkqzcR06HpgN/OCOmtp1tum+zsmO3kb1yjlmYcxsW3AqtZBvOVmKsTeHfAJgt9uKvoW770kGXRPnCpqpJ6eCs47sOTNrwyUJIOwyFbZKFicgeFygIjnU5sL7NWMC8ZE/bGWMXjpbzx4jXYgwQrSbY5kIoH+aZXg4UyVczX6vv/7ItE4VhxPMMI+eRC/sqK3A/fbRvDnwyWnwRfNnQhfG5bCMFgF1TEKsHBt3SZjPTqr1WGn8B8loVLOw1LVpmBWBNOy0hUiSGq5ZZ8ZNOvJa3Nuno3+6TfmB0r/jmg2CgARdLkGhjtVbhsRIpT4SbEppo66LEUFhhuWmi9Y0G2sbV2HjKFUw0cCX7zezH/d8h2BeNyfSZ0gYKC1OWnnlY8d+mcVZLmd3V46YUM/rplVZMlE0jxPrF6aS6ePtDh694tgLEHBgSExDzqNMeACYjM674X6rKoOcX34pHu3MegnA8s7TUB1d4RexS2IsHB4cPurR4wcdAKIAqpFO3u07Ab0TxV0YuJuiwS2r3cckFsf107T7uT8TPRxfUv57Qncdd2XomS6+VsE6TIfyfgDnkoIoADUG+625V1EXiYnsUUCTrcdkr2HkGXBRxqY8B7t76tEe6IryoG4yl6uiOG3afqaOJjKedHEvf4K2+Sc=
+    on_success: never
+    template:
+    - Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository_slug}@%{branch}%{result}
+deploy:
+  provider: pypi
+  user: Avalara
+  password:
+    secure: H4MQ6af8IdGleXgbvItT8Od708LR5nVeFS2KSk4xVC89NPXpfkWsBHMTZ/DgdaIHsoRAIzmFU+wwaz1p7gmTcoH0S/EbG+kBNlSrsgzkvntFQdQnDolkTozRkUUhMeS4MxwoSb/hrSByJcgp2rDhAcTAw22SJQ6zDArhPnTUWnWxkq1xmCHKi8r835iQcJu5jIYV+ePhrsc7v9MbHCj148NRjyfLpuSsJTF4vmD551dbvGjR0x6hxU06DZN++SQfNX3EkolRzuvemeAleWWlK54oI+OuQPLmtNlehPX1IkqfCCDC9Txvcl6nyDNATumnMvt2xtuAHyCYiLAUKTYYwtsYPOzwTDcEcR6mgNeN6KvPCLekngX25sNx4wBAKnKwT0L+2Uf9tH5rQntpw4OA8LVfGQZrxTnvn96KZ36Ga1siFu02p8HH2EykpZd7pfiamCrrRGVKE8Ttamm0BqKK2+2q01Eq2c5md8YkS3UE3K/3Cffpv1gJtWH1p6rM5I+KLN3J4WMxU3TVmRKQJho6y095Hj2DlHFAuiF/N8k266P7lnGKLmmj8q1o1HPanT/mDokY+0D1sTQf7It4HGhcLzObDp8PvOHncBBWH/tRdq3dKxVjnY6q3KVcPwRqUhOlVSUagW1tOYCk49sEbuE93/FyYqILHLypAqckVmrEJKY=
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ notifications:
   email: false
   slack:
     rooms:
-    - secure: R8rDp7cXw0h40KKgUSg/VlZsf8y5FkqzcR06HpgN/OCOmtp1tum+zsmO3kb1yjlmYcxsW3AqtZBvOVmKsTeHfAJgt9uKvoW770kGXRPnCpqpJ6eCs47sOTNrwyUJIOwyFbZKFicgeFygIjnU5sL7NWMC8ZE/bGWMXjpbzx4jXYgwQrSbY5kIoH+aZXg4UyVczX6vv/7ItE4VhxPMMI+eRC/sqK3A/fbRvDnwyWnwRfNnQhfG5bCMFgF1TEKsHBt3SZjPTqr1WGn8B8loVLOw1LVpmBWBNOy0hUiSGq5ZZ8ZNOvJa3Nuno3+6TfmB0r/jmg2CgARdLkGhjtVbhsRIpT4SbEppo66LEUFhhuWmi9Y0G2sbV2HjKFUw0cCX7zezH/d8h2BeNyfSZ0gYKC1OWnnlY8d+mcVZLmd3V46YUM/rplVZMlE0jxPrF6aS6ePtDh694tgLEHBgSExDzqNMeACYjM674X6rKoOcX34pHu3MegnA8s7TUB1d4RexS2IsHB4cPurR4wcdAKIAqpFO3u07Ab0TxV0YuJuiwS2r3cckFsf107T7uT8TPRxfUv57Qncdd2XomS6+VsE6TIfyfgDnkoIoADUG+625V1EXiYnsUUCTrcdkr2HkGXBRxqY8B7t76tEe6IryoG4yl6uiOG3afqaOJjKedHEvf4K2+Sc=
+      - secure: R8rDp7cXw0h40KKgUSg/VlZsf8y5FkqzcR06HpgN/OCOmtp1tum+zsmO3kb1yjlmYcxsW3AqtZBvOVmKsTeHfAJgt9uKvoW770kGXRPnCpqpJ6eCs47sOTNrwyUJIOwyFbZKFicgeFygIjnU5sL7NWMC8ZE/bGWMXjpbzx4jXYgwQrSbY5kIoH+aZXg4UyVczX6vv/7ItE4VhxPMMI+eRC/sqK3A/fbRvDnwyWnwRfNnQhfG5bCMFgF1TEKsHBt3SZjPTqr1WGn8B8loVLOw1LVpmBWBNOy0hUiSGq5ZZ8ZNOvJa3Nuno3+6TfmB0r/jmg2CgARdLkGhjtVbhsRIpT4SbEppo66LEUFhhuWmi9Y0G2sbV2HjKFUw0cCX7zezH/d8h2BeNyfSZ0gYKC1OWnnlY8d+mcVZLmd3V46YUM/rplVZMlE0jxPrF6aS6ePtDh694tgLEHBgSExDzqNMeACYjM674X6rKoOcX34pHu3MegnA8s7TUB1d4RexS2IsHB4cPurR4wcdAKIAqpFO3u07Ab0TxV0YuJuiwS2r3cckFsf107T7uT8TPRxfUv57Qncdd2XomS6+VsE6TIfyfgDnkoIoADUG+625V1EXiYnsUUCTrcdkr2HkGXBRxqY8B7t76tEe6IryoG4yl6uiOG3afqaOJjKedHEvf4K2+Sc=
+    only: master
     on_success: never
     template:
-    - Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository_slug}@%{branch}%{result}
+      - Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository_slug}@%{branch}%{result}
 deploy:
   provider: pypi
   user: Avalara

--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@
 This GitHub repository is the Python SDK for Avalara's world-class tax service, AvaTax.  It uses the AvaTax REST v2 API, which is a fully REST implementation and provides a single client for all AvaTax functionality.  For more information about AvaTax REST v2, please visit [Avalara's Developer Network](http://developer.avalara.com/) or view the [online Swagger documentation](https://sandbox-rest.avatax.com/swagger/ui/index.html).
 
 
-### **Meet the Team:**
-
-[Han Bao](https://www.linkedin.com/in/hbao2016)
-
-[Philip Werner](https://www.linkedin.com/in/philip-werner-421aa66a)
-
-[Robert Bronson](https://www.linkedin.com/in/robert-bronson)
-
-[Adrienne Karnoski](https://www.linkedin.com/in/adrienne-karnoski)
-
 ## **Set Up and Installation:**
 
 Clone this repository to your local machine.
@@ -39,7 +29,6 @@ Python_Final $ source ENV/bin/activate
 
 ## **Usage:**
 
-
 ### **Configuration**
 
 **Environment**
@@ -62,19 +51,20 @@ Add the following to the ```activate``` file in your environment:
 ```
   bash
 # Username and password
-USERNAME='your_sandbox_username'
-PASSWORD='your_sandbox_password'
+SANDBOX_USERNAME='your_sandbox_username'
+SANDBOX_PASSWORD='your_sandbox_password'
 
 # Or account id and license key
-ACCOUNT_ID='your_sandbox_account_id'
-LICENSE_KEY='your_sandbox_license_key'
+SANDBOX_ACCOUNTID='your_sandbox_account_id'
+SANDBOX_LICENSEKEY='your_sandbox_license_key'
 ```
-Setting up environmental variables for production mode is similar:
+Note: Only *Sandbox credentials* should be used for testing, as the test case will commit/adjust/void dummy transactions on the account to verify functionalities.  
+You may store testing credentials onto the `activate` script within your `ENV/bin`:  
 ```
-export USERNAME='<your-username>'
-export PASSWORD='<your-password>'
-export ACCOUNT_ID='<your-account-id>'
-export LICENSE_KEY='<your-license-key>'
+export SANDBOX_USERNAME='<your-username>'
+export SANDBOX_PASSWORD='<your-password>'
+export SANDBOX_ACCOUNTID='<your-account-id>'
+export SANDBOX_LICENSEKEY='<your-license-key>'
 ```
 **Import the python AvaTaxClient from the client module:**
 
@@ -131,3 +121,12 @@ address = {
 return print(client.resolveAddress(address))
 ```
 
+### **Contributors:**
+
+[Han Bao](https://www.linkedin.com/in/hbao2016)
+
+[Philip Werner](https://www.linkedin.com/in/philip-werner-421aa66a)
+
+[Robert Bronson](https://www.linkedin.com/in/robert-bronson)
+
+[Adrienne Karnoski](https://www.linkedin.com/in/adrienne-karnoski)

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     description='Avalara Tax Python SDK.',
     install_requires=['requests', 'ipython'],
     extras_require={
-        "test": ['pytest', 'pytest-cov', 'tox']
+        "test": ['pytest', 'pytest-cov', 'tox', 'Faker']
     })

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     description='Avalara Tax Python SDK.',
     install_requires=['requests', 'ipython'],
     extras_require={
-        "test": ['pytest', 'pytest-cov', 'tox', 'Faker']
+        "test": ['pytest', 'pytest-cov', 'tox']
     })

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ setup(
     name='Avalara Python SDK',
     package_dir={'': 'src'},
     py_modules=[
-        'client', 
-        'client_methods', 
-        'transaction_builder', 
+        'client',
+        'client_methods',
+        'transaction_builder',
         'transaction_builder_methods',
         '_str_version'
     ],
     author='Han Bao, Adrienne Karnoski, Robert Bronson, Philip Werner',
-    author_email='hbao2016@hotmail.com',
+    author_email='han.bao@avalara.com',
     description='Avalara Tax Python SDK.',
     install_requires=['requests', 'ipython'],
     extras_require={

--- a/src/client.py
+++ b/src/client.py
@@ -80,32 +80,32 @@ class AvataxClient(client_methods.Mixin):
         return self
 
 # to generate a client object on initialization of this file, uncomment the script below
-if __name__ == '__main__':  # pragma no cover
-    """Creating a client with credential, must have env variables username & password."""
-    client = AvataxClient('my test app',
-                          'ver 0.0',
-                          'my test machine',
-                          'sandbox')
-    c = client.add_credentials(os.environ.get('USERNAME', ''),
-                               os.environ.get('PASSWORD', ''))
-    print(client.ping().text)
-    tax_document = {
-        'addresses': {'SingleLocation': {'city': 'Irvine',
-                                         'country': 'US',
-                                         'line1': '123 Main Street',
-                                         'postalCode': '92615',
-                                         'region': 'CA'}},
-        'commit': False,
-        'companyCode': 'DEFAULT',
-        'currencyCode': 'USD',
-        'customerCode': 'ABC',
-        'date': '2017-04-12',
-        'description': 'Yarn',
-        'lines': [{'amount': 100,
-                  'description': 'Yarn',
-                   'itemCode': 'Y0001',
-                   'number': '1',
-                   'quantity': 1,
-                   'taxCode': 'PS081282'}],
-        'purchaseOrderNo': '2017-04-12-001',
-        'type': 'SalesInvoice'}
+# if __name__ == '__main__':  # pragma no cover
+#     """Creating a client with credential, must have env variables username & password."""
+#     client = AvataxClient('my test app',
+#                           'ver 0.0',
+#                           'my test machine',
+#                           'sandbox')
+#     c = client.add_credentials(os.environ.get('USERNAME', ''),
+#                                os.environ.get('PASSWORD', ''))
+#     print(client.ping().text)
+#     tax_document = {
+#         'addresses': {'SingleLocation': {'city': 'Irvine',
+#                                          'country': 'US',
+#                                          'line1': '123 Main Street',
+#                                          'postalCode': '92615',
+#                                          'region': 'CA'}},
+#         'commit': False,
+#         'companyCode': 'DEFAULT',
+#         'currencyCode': 'USD',
+#         'customerCode': 'ABC',
+#         'date': '2017-04-12',
+#         'description': 'Yarn',
+#         'lines': [{'amount': 100,
+#                   'description': 'Yarn',
+#                    'itemCode': 'Y0001',
+#                    'number': '1',
+#                    'quantity': 1,
+#                    'taxCode': 'PS081282'}],
+#         'purchaseOrderNo': '2017-04-12-001',
+#         'type': 'SalesInvoice'}

--- a/src/client.py
+++ b/src/client.py
@@ -18,6 +18,7 @@ file that was distributed with this source code.
 from requests.auth import HTTPBasicAuth
 from _str_version import str_type
 import client_methods
+import os
 
 
 class AvataxClient(client_methods.Mixin):
@@ -79,32 +80,32 @@ class AvataxClient(client_methods.Mixin):
         return self
 
 # to generate a client object on initialization of this file, uncomment the script below
-# if __name__ == '__main__':  # pragma no cover
-#     """Creating a client with credential, must have env variables username & password."""
-#     client = AvataxClient('my test app',
-#                           'ver 0.0',
-#                           'my test machine',
-#                           'sandbox')
-#     c = client.add_credentials(os.environ.get('USERNAME', ''),
-#                                os.environ.get('PASSWORD', ''))
-#     print(client.ping().text)
-#     tax_document = {
-#         'addresses': {'SingleLocation': {'city': 'Irvine',
-#                                          'country': 'US',
-#                                          'line1': '123 Main Street',
-#                                          'postalCode': '92615',
-#                                          'region': 'CA'}},
-#         'commit': False,
-#         'companyCode': 'DEFAULT',
-#         'currencyCode': 'USD',
-#         'customerCode': 'ABC',
-#         'date': '2017-04-12',
-#         'description': 'Yarn',
-#         'lines': [{'amount': 100,
-#                   'description': 'Yarn',
-#                    'itemCode': 'Y0001',
-#                    'number': '1',
-#                    'quantity': 1,
-#                    'taxCode': 'PS081282'}],
-#         'purchaseOrderNo': '2017-04-12-001',
-#         'type': 'SalesInvoice'}
+if __name__ == '__main__':  # pragma no cover
+    """Creating a client with credential, must have env variables username & password."""
+    client = AvataxClient('my test app',
+                          'ver 0.0',
+                          'my test machine',
+                          'sandbox')
+    c = client.add_credentials(os.environ.get('USERNAME', ''),
+                               os.environ.get('PASSWORD', ''))
+    print(client.ping().text)
+    tax_document = {
+        'addresses': {'SingleLocation': {'city': 'Irvine',
+                                         'country': 'US',
+                                         'line1': '123 Main Street',
+                                         'postalCode': '92615',
+                                         'region': 'CA'}},
+        'commit': False,
+        'companyCode': 'DEFAULT',
+        'currencyCode': 'USD',
+        'customerCode': 'ABC',
+        'date': '2017-04-12',
+        'description': 'Yarn',
+        'lines': [{'amount': 100,
+                  'description': 'Yarn',
+                   'itemCode': 'Y0001',
+                   'number': '1',
+                   'quantity': 1,
+                   'taxCode': 'PS081282'}],
+        'purchaseOrderNo': '2017-04-12-001',
+        'type': 'SalesInvoice'}

--- a/src/client.py
+++ b/src/client.py
@@ -16,7 +16,6 @@ file that was distributed with this source code.
 @link       https://github.com/avadev/AvaTax-REST-V2-Python-SDK
 """
 from requests.auth import HTTPBasicAuth
-import os
 from _str_version import str_type
 import client_methods
 
@@ -53,9 +52,9 @@ class AvataxClient(client_methods.Mixin):
         self.app_name = app_name
         self.app_version = app_version
         self.machine_name = machine_name
-        self.client_id = '{};{};python_sdk;17.6;{};'.format(app_name,
-                                                            app_version,
-                                                            machine_name)
+        self.client_id = '{}; {}; Python SDK; 18.2; {};'.format(app_name,
+                                                                app_version,
+                                                                machine_name)
         self.client_header = {'X-Avalara-Client': self.client_id}
 
     def add_credentials(self, username=None, password=None):
@@ -80,32 +79,32 @@ class AvataxClient(client_methods.Mixin):
         return self
 
 # to generate a client object on initialization of this file, uncomment the script below
-if __name__ == '__main__':  # pragma no cover
-    """Creating a client with credential, must have env variables username & password."""
-    client = AvataxClient('my test app',
-                          'ver 0.0',
-                          'my test machine',
-                          'sandbox')
-    c = client.add_credentials(os.environ.get('USERNAME', ''),
-                               os.environ.get('PASSWORD', ''))
-    print(client.ping().text)
-    tax_document = {
-        'addresses': {'SingleLocation': {'city': 'Irvine',
-                                         'country': 'US',
-                                         'line1': '123 Main Street',
-                                         'postalCode': '92615',
-                                         'region': 'CA'}},
-        'commit': False,
-        'companyCode': 'DEFAULT',
-        'currencyCode': 'USD',
-        'customerCode': 'ABC',
-        'date': '2017-04-12',
-        'description': 'Yarn',
-        'lines': [{'amount': 100,
-                  'description': 'Yarn',
-                   'itemCode': 'Y0001',
-                   'number': '1',
-                   'quantity': 1,
-                   'taxCode': 'PS081282'}],
-        'purchaseOrderNo': '2017-04-12-001',
-        'type': 'SalesInvoice'}
+# if __name__ == '__main__':  # pragma no cover
+#     """Creating a client with credential, must have env variables username & password."""
+#     client = AvataxClient('my test app',
+#                           'ver 0.0',
+#                           'my test machine',
+#                           'sandbox')
+#     c = client.add_credentials(os.environ.get('USERNAME', ''),
+#                                os.environ.get('PASSWORD', ''))
+#     print(client.ping().text)
+#     tax_document = {
+#         'addresses': {'SingleLocation': {'city': 'Irvine',
+#                                          'country': 'US',
+#                                          'line1': '123 Main Street',
+#                                          'postalCode': '92615',
+#                                          'region': 'CA'}},
+#         'commit': False,
+#         'companyCode': 'DEFAULT',
+#         'currencyCode': 'USD',
+#         'customerCode': 'ABC',
+#         'date': '2017-04-12',
+#         'description': 'Yarn',
+#         'lines': [{'amount': 100,
+#                   'description': 'Yarn',
+#                    'itemCode': 'Y0001',
+#                    'number': '1',
+#                    'quantity': 1,
+#                    'taxCode': 'PS081282'}],
+#         'purchaseOrderNo': '2017-04-12-001',
+#         'type': 'SalesInvoice'}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,26 +12,10 @@ def unauth_client():
 
 
 @pytest.fixture(scope='session')
-def auth_client_loggedin_with_username():
-    """Create an instance of SanboxClient with authentification using username/password pair."""
-    client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
-    return client
-
-
-@pytest.fixture(scope='session')
 def auth_client():
     """Create an instance of SanboxClient with authentification using username/password pair."""
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
-    return client
-
-
-@pytest.fixture(scope='session')
-def auth_client_loggedin_with_id():
-    """Create an instance of SanboxClient with authentification using userID/licenseKey pair."""
-    client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
+    client.add_credentials(os.environ.get('SANDBOX_USERNAME', ''), os.environ.get('SANDBOX_PASSWORD', ''))
     return client
 
 
@@ -39,7 +23,7 @@ def auth_client_loggedin_with_id():
 def mt_trans():
     """Create an instance of Transaction Builder object."""
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
+    client.add_credentials(os.environ.get('SANDBOX_USERNAME', ''), os.environ.get('SANDBOX_PASSWORD', ''))
     trans = TransactionBuilder(client, 'DEFAULT', 'SalesInvoice', 'ABC123')
     return trans
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,8 @@ def cred_determine():
         return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
     elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
         return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
+    elif os.environ.get('USERNAME') and os.environ.get('PASSWORD'):
+        return (os.environ.get('USERNAME'), os.environ.get('PASSWORD'))
     else:
         raise ValueError()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,20 @@ def single_transaction():
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
     login_key, login_val = cred_determine()
     client.add_credentials(login_key, login_val)
-
     tax_document = default_trans_model()
+    r = client.create_transaction(tax_document, 'DEFAULT')
+    trans_code = r.json()['code']
+    return trans_code
+
+
+@pytest.fixture(scope='function')
+def single_transaction_purchase_invoice():
+    """Create an instance of AvataxClient with authentication and created transaction(purchase invoice)."""
+    client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
+    login_key, login_val = cred_determine()
+    client.add_credentials(login_key, login_val)
+    tax_document = default_trans_model()
+    tax_document['type'] = 'PurchaseInvoice'
     r = client.create_transaction(tax_document, 'DEFAULT')
     trans_code = r.json()['code']
     return trans_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,24 @@ def tax_document():
     """Create a tax document dictionary."""
     return default_trans_model()
 
+@pytest.fixture(scope='function')
+def init_comp_model():
+    """Return the following initialize company model for company DEFAULT."""
+    return {
+        "name": "Bobs Artisan Pottery",
+        "companyCode": 'DEFAULT',
+        "taxpayerIdNumber": "12-3456789",
+        "line1": "2000 Main Street",
+        "city": "Irvine",
+        "region": "CA",
+        "postalCode": "92614",
+        "country": "US",
+        "firstName": "Bob",
+        "lastName": "Example",
+        "title": "Owner",
+        "email": "bob@example.org",
+        "phoneNumber": "714 555-2121",
+        "mobileNumber": "714 555-1212"}
 
 def cred_determine():
     """Return the appropriate pair of cred."""
@@ -136,7 +154,6 @@ def cred_determine():
         return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
     else:
         raise ValueError()
-
 
 def default_trans_model():
     """Return the default transaction model."""
@@ -160,4 +177,19 @@ def default_trans_model():
                    'taxCode': 'PS081282'}],
         'purchaseOrderNo': '2017-04-12-001',
         'type': 'SalesInvoice'}
+
+def pytest_runtest_makereport(item, call):
+    """For incremental testing fixture called mark.increment."""
+    if "incremental" in item.keywords:
+        if call.excinfo is not None:
+            parent = item.parent
+            parent._previousfailed = item
+
+def pytest_runtest_setup(item):
+    """For incremental testing fixture called mark.increment."""
+    if "incremental" in item.keywords:
+        previousfailed = getattr(item.parent, "_previousfailed", None)
+        if previousfailed is not None:
+            pytest.xfail("previous test failed (%s)" %previousfailed.name)
+
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,23 +22,12 @@ def auth_client():
     client.add_credentials(os.environ.get('SANDBOX_USERNAME', ''), os.environ.get('SANDBOX_PASSWORD', ''))
     return client
 
-def cred_determine():
-    """Return the appropriate pair of cred."""
-    if os.environ.get('SANDBOX_USERNAME') and os.environ.get('SANDBOX_PASSWORD'):
-        return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
-    elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
-        return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
-    else:
-        raise ValueError()
 
 @pytest.fixture(scope='function')
 def mt_trans():
     """Create an instance of Transaction Builder object."""
-    try:
-        login_key, login_val = cred_determine()
-    except ValueError:
-        raise ValueError('must store a pair of credentials into the running environment!')
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
+    login_key, login_val = cred_determine()
     client.add_credentials(login_key, login_val)
     trans = TransactionBuilder(client, 'DEFAULT', 'SalesInvoice', 'ABC123')
     return trans
@@ -72,7 +61,9 @@ def ship_from_address():
 def single_transaction():
     """Create an instance of AvataxClient with authentication and created transaction."""
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
+    login_key, login_val = cred_determine()
+    client.add_credentials(login_key, login_val)
+
     tax_document = {
         'addresses': {'SingleLocation': {'city': 'Irvine',
                                          'country': 'US',
@@ -103,7 +94,8 @@ def five_transactions():
     """Create an instance of AvataxClient with authentication and created transaction."""
     trans_codes = []
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('USERNAME', ''), os.environ.get('PASSWORD', ''))
+    login_key, login_val = cred_determine()
+    client.add_credentials(login_key, login_val)
     addresses = [
         ('Seattle', '600 5th Ave', '98104', 'WA'),
         ('Poulsbo', '200 Moe St Ne', '98370', 'WA'),
@@ -161,3 +153,12 @@ def tax_document():
         'purchaseOrderNo': '2017-04-12-001',
         'type': 'SalesInvoice'}
 
+
+def cred_determine():
+    """Return the appropriate pair of cred."""
+    if os.environ.get('SANDBOX_USERNAME') and os.environ.get('SANDBOX_PASSWORD'):
+        return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
+    elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
+        return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
+    else:
+        raise ValueError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,26 +64,7 @@ def single_transaction():
     login_key, login_val = cred_determine()
     client.add_credentials(login_key, login_val)
 
-    tax_document = {
-        'addresses': {'SingleLocation': {'city': 'Irvine',
-                                         'country': 'US',
-                                         'line1': '123 Main Street',
-                                         'postalCode': '92615',
-                                         'region': 'CA'}},
-        'commit': False,
-        'companyCode': 'DEFAULT',
-        'currencyCode': 'USD',
-        'customerCode': 'ABC',
-        'date': '2017-04-12',
-        'description': 'Yarn',
-        'lines': [{'amount': 100,
-                  'description': 'Yarn',
-                   'itemCode': 'Y0001',
-                   'number': '1',
-                   'quantity': 1,
-                   'taxCode': 'PS081282'}],
-        'purchaseOrderNo': '2017-04-12-001',
-        'type': 'SalesInvoice'}
+    tax_document = default_trans_model()
     r = client.create_transaction(tax_document, 'DEFAULT')
     trans_code = r.json()['code']
     return trans_code
@@ -132,6 +113,21 @@ def five_transactions():
 @pytest.fixture(scope='function')
 def tax_document():
     """Create a tax document dictionary."""
+    return default_trans_model()
+
+
+def cred_determine():
+    """Return the appropriate pair of cred."""
+    if os.environ.get('SANDBOX_USERNAME') and os.environ.get('SANDBOX_PASSWORD'):
+        return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
+    elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
+        return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
+    else:
+        raise ValueError()
+
+
+def default_trans_model():
+    """Return the default transaction model."""
     return {
         'addresses': {'SingleLocation': {'city': 'Irvine',
                                          'country': 'US',
@@ -153,12 +149,3 @@ def tax_document():
         'purchaseOrderNo': '2017-04-12-001',
         'type': 'SalesInvoice'}
 
-
-def cred_determine():
-    """Return the appropriate pair of cred."""
-    if os.environ.get('SANDBOX_USERNAME') and os.environ.get('SANDBOX_PASSWORD'):
-        return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
-    elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
-        return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
-    else:
-        raise ValueError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,16 +14,32 @@ def unauth_client():
 @pytest.fixture(scope='session')
 def auth_client():
     """Create an instance of SanboxClient with authentification using username/password pair."""
+    try:
+        login_key, login_val = cred_determine()
+    except ValueError:
+        return None
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
     client.add_credentials(os.environ.get('SANDBOX_USERNAME', ''), os.environ.get('SANDBOX_PASSWORD', ''))
     return client
 
+def cred_determine():
+    """Return the appropriate pair of cred."""
+    if os.environ.get('SANDBOX_USERNAME') and os.environ.get('SANDBOX_PASSWORD'):
+        return (os.environ.get('SANDBOX_USERNAME'), os.environ.get('SANDBOX_PASSWORD'))
+    elif os.environ.get('SANDBOX_CLIENTID') and os.environ.get('SANDBOX_LICENSEKEY'):
+        return (os.environ.get('SANDBOX_CLIENTID'), os.environ.get('SANDBOX_LICENSEKEY'))
+    else:
+        raise ValueError()
 
 @pytest.fixture(scope='function')
 def mt_trans():
     """Create an instance of Transaction Builder object."""
+    try:
+        login_key, login_val = cred_determine()
+    except ValueError:
+        raise ValueError('must store a pair of credentials into the running environment!')
     client = AvataxClient('test app', 'ver 0.0', 'test machine', 'sandbox')
-    client.add_credentials(os.environ.get('SANDBOX_USERNAME', ''), os.environ.get('SANDBOX_PASSWORD', ''))
+    client.add_credentials(login_key, login_val)
     trans = TransactionBuilder(client, 'DEFAULT', 'SalesInvoice', 'ABC123')
     return trans
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -55,3 +55,8 @@ def test_no_auth_if_no_cred_is_added(unauth_client):
     """Test client object auth property is None by default."""
     assert unauth_client.auth is None
 
+
+def test_if_valid_pair_sandbox_cred_in_place(auth_client):
+    """Test if there is a pair of valid Avatax credentials stored in env."""
+    assert auth_client is not None
+

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -29,13 +29,37 @@ class TestBasicWorkFlow(object):
 		"""Create a transaction(save it only) using the company created(DEFAULT)."""
 		tax_document['commit'] = False
 		response = auth_client.create_transaction(tax_document, None)
+		assert response.status_code == 201
 		assert response.json()['status'] == 'Saved'
 		auth_client.trans_code = response.json()['code']
 
 	def test_verfiy_transaction(self, auth_client):
 		"""Verify the transaction that has been created."""
 		response = auth_client.verify_transaction('DEFAULT', auth_client.trans_code, {})
+		assert response.status_code == 200
 		assert response.json()['status'] == 'Posted'
+
+	def test_commit_transaction(self, auth_client):
+		"""Commit the transaction that has been saved."""
+		model = {'commit': True}
+		response = auth_client.commit_transaction('DEFAULT', auth_client.trans_code, model)
+		assert response.status_code == 200
+		assert response.json()['status'] == 'Committed'
+
+	def test_adjust_transaction(self, auth_client, tax_document):
+		"""Adjust the transaction just committed."""
+		tax_document['commit'] = True
+		tax_document['lines'][0]['amount'] =80
+		model = {
+					'adjustmentReason': 'PriceAdjusted',
+					'adjustmentDescription': 'Price drop before shipping.',
+					'newTransaction': tax_document
+				}
+		response = auth_client.adjust_transaction('DEFAULT', auth_client.trans_code, model)
+		assert response.status_code == 200
+		assert response.json()['adjustmentReason'] == 'PriceAdjusted'
+
+
 
 
 

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -16,7 +16,7 @@ class TestBasicWorkFlow(object):
 		"""Test credential is valid."""
 		assert '"authenticated":true' in auth_client.ping().text
 
-	def test_check_default_company_exist(self, auth_client):
+	def test_check_default_company_exist(self, auth_client, init_comp_model):
 		"""Test if the user has default company set up already, create one otherwise."""
 		response = auth_client.query_companies()
 		assert response.status_code == 200
@@ -49,7 +49,7 @@ class TestBasicWorkFlow(object):
 	def test_adjust_transaction(self, auth_client, tax_document):
 		"""Adjust the transaction just committed."""
 		tax_document['commit'] = True
-		tax_document['lines'][0]['amount'] =80
+		tax_document['lines'][0]['amount'] = 80
 		model = {
 					'adjustmentReason': 'PriceAdjusted',
 					'adjustmentDescription': 'Price drop before shipping.',

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -1,0 +1,41 @@
+"""
+Ensure all methods needed for new user are functional, including going through
+the Transaction State Diagram to verify all methods needed for the lifecycle of 
+a single transaction works properly.
+"""
+from faker import Faker
+import pytest
+
+client_info = {
+	'company_name': None,
+
+}
+
+
+@pytest.mark.incremental  # allow "test-step" : only continue to next test if previous ones all pass
+class TestBasicWorkFlow(object):
+	def test_connection(self, auth_client):
+		"""Test internet connection of the testing env."""
+		assert auth_client.ping().status_code == 200
+
+	def test_ping(self, auth_client):
+		"""Test credential is valid."""
+		assert '"authenticated":true' in auth_client.ping().text
+
+	def test_company_initialization(self, auth_client, init_comp_model):
+		"""Test a basic company can be initalized."""
+		fake = Faker()
+		comp_name = fake.first_name().upper()  # create new company each time test is run to prevent conflict
+		model = init_comp_model
+		model['companyCode'] = comp_name
+		response = auth_client.company_initialize(model)
+		assert response.status_code == 201
+		if response.status_code == 201:
+			assert response.json()['isActive'] == True
+			client_info['company_name'] = comp_name
+
+	def test_create_transaction(auth_client):
+		"""Create a transaction using the company just created"""
+		pass
+
+

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -3,13 +3,7 @@ Ensure all methods needed for new user are functional, including going through
 the Transaction State Diagram to verify all methods needed for the lifecycle of 
 a single transaction works properly.
 """
-from faker import Faker
 import pytest
-
-client_info = {
-	'company_name': None,
-
-}
 
 
 @pytest.mark.incremental  # allow "test-step" : only continue to next test if previous ones all pass
@@ -22,20 +16,27 @@ class TestBasicWorkFlow(object):
 		"""Test credential is valid."""
 		assert '"authenticated":true' in auth_client.ping().text
 
-	def test_company_initialization(self, auth_client, init_comp_model):
-		"""Test a basic company can be initalized."""
-		fake = Faker()
-		comp_name = fake.first_name().upper()  # create new company each time test is run to prevent conflict
-		model = init_comp_model
-		model['companyCode'] = comp_name
-		response = auth_client.company_initialize(model)
-		assert response.status_code == 201
-		if response.status_code == 201:
+	def test_check_default_company_exist(self, auth_client):
+		"""Test if the user has default company set up already, create one otherwise."""
+		response = auth_client.query_companies()
+		assert response.status_code == 200
+		if '"companyCode":"DEFAULT"' not in response.text:
+			response = auth_client.company_initialize(init_comp_model)
+			assert response.status_code == 201
 			assert response.json()['isActive'] == True
-			client_info['company_name'] = comp_name
 
-	def test_create_transaction(auth_client):
-		"""Create a transaction using the company just created"""
-		pass
+	def test_create_transaction(self, auth_client, tax_document):
+		"""Create a transaction(save it only) using the company created(DEFAULT)."""
+		tax_document['commit'] = False
+		response = auth_client.create_transaction(tax_document, None)
+		assert response.json()['status'] == 'Saved'
+		auth_client.trans_code = response.json()['code']
+
+	def test_verfiy_transaction(self, auth_client):
+		"""Verify the transaction that has been created."""
+		response = auth_client.verify_transaction('DEFAULT', auth_client.trans_code, {})
+		assert response.json()['status'] == 'Posted'
+
+
 
 

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -6,7 +6,7 @@ a single transaction works properly.
 import pytest
 
 
-@pytest.mark.incremental  # allow "test-step" : only continue to next test if previous ones all pass
+@pytest.mark.incremental  # allow "test-step" : only continue to next test if previous ones all passes
 class TestBasicWorkFlow(object):
 	def test_connection(self, auth_client):
 		"""Test internet connection of the testing env."""
@@ -59,8 +59,10 @@ class TestBasicWorkFlow(object):
 		assert response.status_code == 200
 		assert response.json()['adjustmentReason'] == 'PriceAdjusted'
 
-
-
-
-
+	def test_void_transaction(self, auth_client):
+		"""Void the transaction we just adjusted(still committed status)."""
+		model = {'code': 'DocVoided'}
+		response = auth_client.void_transaction('DEFAULT', auth_client.trans_code, model)
+		assert response.status_code == 200
+		assert response.json()['status'] == 'Cancelled'
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,5 +29,17 @@ def test_client_has_machine_name_attribute(unauth_client):
 
 def test_that_client_id_is_created(unauth_client):
     """Test that the client id is created and properly formatted."""
-    assert unauth_client.client_id == 'test app;ver 0.0;python_sdk;17.6;test machine;'
+    assert unauth_client.client_id == 'test app; ver 0.0; Python SDK; 18.2; test machine;'
+
+
+def test_client_can_obtain_production_url_as_base_url():
+    """Test the default option for base url is production url."""
+    client = AvataxClient('test app', 'ver 0.0', 'test machine')
+    assert client.base_url == 'https://rest.avatax.com'
+
+
+def test_client_can_obtain_their_own_base_url():
+    """Test the client can input a url as the base url."""
+    client = AvataxClient('test app', 'ver 0.0', 'test machine', 'https://myurl.com')
+    assert client.base_url == 'https://myurl.com'
 

--- a/tests/test_commit_trans.py
+++ b/tests/test_commit_trans.py
@@ -1,32 +1,15 @@
 """Test module for Commit Transaction method."""
-import pytest
 
 
-# def test_commit_transaction_with_invalid_company_code_type(auth_client):
-#     """Test if an error is raised with invalid input type."""
-#     trans_code = '94affa7f-b691-41ad-9048-301cdceaffc8'
-#     with pytest.raises(ValueError):
-#         auth_client.commit_transaction(None, {'code': trans_code})
-
-
-# def test_commit_transaction_with_invaild_trans_code_type(auth_client):
-#     """Test if an error is raised with lack of required variable."""
-#     comp_code = 'DEFAULT'
-#     with pytest.raises(ValueError):
-#         auth_client.commit_transaction({'code': comp_code}, None)
-
-
-def test_commit_transaction_commit_saved_trans(auth_client, five_transactions):
+def test_commit_transaction_commit_saved_trans(auth_client, single_transaction):
     """Test if we can commit non-commited/saved trans."""
-    for t_code in five_transactions:
-        r = auth_client.commit_transaction('DEFAULT', t_code, {'commit': True})
-        assert r.json()['status'] == 'Committed'
+    r = auth_client.commit_transaction('DEFAULT', single_transaction, {'commit': True})
+    assert r.json()['status'] == 'Committed'
 
 
-def test_commit_transaction_wont_commit_if_commit_param_false(auth_client, five_transactions):
+def test_commit_transaction_wont_commit_if_commit_param_false(auth_client, single_transaction):
     """Test if the transaction will not commited if commit parameter is false."""
-    for t_code in five_transactions:
-        r = auth_client.commit_transaction('DEFAULT', t_code, {'commit': False})
-        assert r.json()['status'] == 'Saved'
-
+    r = auth_client.commit_transaction('DEFAULT', single_transaction, {'commit': False})
+    # import pdb; pdb.set_trace()
+    assert r.json()['status'] == 'Saved'
 

--- a/tests/test_create_trans.py
+++ b/tests/test_create_trans.py
@@ -3,12 +3,6 @@ import pytest
 from requests import Response
 
 
-# def test_error_raises_invalid_type(auth_client):
-#     """Test that an error is raised with inproper input type."""
-#     with pytest.raises(ValueError):
-#         auth_client.create_transaction(model='invalid_transaction')
-
-
 def test_201_response_when_creating_transaction(auth_client, tax_document):
     """Test recieving 200 status code when valid data passed in."""
     r = auth_client.create_transaction(tax_document, None)

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -26,4 +26,3 @@ def test_ping_auth_with_invalid_account_id(unauth_client):
     """Testing client without proper account id and license key."""
     unauth_client.add_credentials('1234', '4321')
     assert '"authenticated":false' in unauth_client.ping().text
-

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -11,14 +11,9 @@ def test_ping_auth_is_false_connection(unauth_client):
     assert '"authenticated":false' in unauth_client.ping().text
 
 
-def test_ping_auth_is_true_connection(auth_client_loggedin_with_username):
+def test_ping_auth_is_true_using_client_id(auth_client):
     """Testing client with authorization from username and password."""
-    assert '"authenticated":true' in auth_client_loggedin_with_username.ping().text
-
-
-def test_ping_auth_is_true_using_client_id(auth_client_loggedin_with_id):
-    """Testing client with authorization from account ID and license key."""
-    assert '"authenticated":true' in auth_client_loggedin_with_id.ping().text
+    assert '"authenticated":true' in auth_client.ping().text
 
 
 def test_ping_auth_with_invalid_user_and_pass(unauth_client):

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -26,3 +26,4 @@ def test_ping_auth_with_invalid_account_id(unauth_client):
     """Testing client without proper account id and license key."""
     unauth_client.add_credentials('1234', '4321')
     assert '"authenticated":false' in unauth_client.ping().text
+

--- a/tests/test_void_transaction.py
+++ b/tests/test_void_transaction.py
@@ -1,5 +1,4 @@
 """Test void transaction method."""
-import pytest
 
 
 def test_imports(single_transaction, auth_client):
@@ -8,33 +7,9 @@ def test_imports(single_transaction, auth_client):
     assert trans_code is not None
 
 
-# def test_void_changes_transaction_status_to(single_transaction, auth_client):
-#     """Test that running void_transaction voids it with default void model."""
-#     result = auth_client.void_transaction('DEFAULT', single_transaction).json()
-#     assert result['status'] == "Cancelled"
-
-
 def test_void_changes_transaction_status_to_with_model(single_transaction, auth_client):
     """Test that running void_transaction voids it."""
     result = auth_client.void_transaction('DEFAULT', single_transaction, {'code':'DocVoided'}).json()
     assert result['status'] == "Cancelled"
 
 
-# def test_void_with_invalid_type_model_info_raises_error(single_transaction, auth_client):
-#     """Test error is raised when called without proper params."""
-#     with pytest.raises(ValueError):
-#         auth_client.void_transaction(code_model={})
-
-
-# def test_void_with_invalid_type_company_code_raises_errror(single_transaction,
-#                                                            auth_client):
-#     """Test error is raised when called without proper params."""
-#     with pytest.raises(ValueError):
-#         auth_client.void_transaction(comp_code=983922)
-
-
-# def test_void_with_invalid_type_transaction_num_raises_error(single_transaction,
-#                                                              auth_client):
-#     """Test error is raised when called without proper params."""
-#     with pytest.raises(ValueError):
-#         auth_client.void_transaction(trans_code=332422234)

--- a/tests/test_void_transaction.py
+++ b/tests/test_void_transaction.py
@@ -2,14 +2,20 @@
 
 
 def test_imports(single_transaction, auth_client):
-    """Test import works without errors."""
-    trans_code = single_transaction
-    assert trans_code is not None
+	"""Test import works without errors."""
+	trans_code = single_transaction
+	assert trans_code is not None
 
 
 def test_void_changes_transaction_status_to_with_model(single_transaction, auth_client):
-    """Test that running void_transaction voids it."""
-    result = auth_client.void_transaction('DEFAULT', single_transaction, {'code':'DocVoided'}).json()
-    assert result['status'] == "Cancelled"
+	"""Test that running void_transaction voids it."""
+	result = auth_client.void_transaction('DEFAULT', single_transaction, {'code':'DocVoided'}).json()
+	assert result['status'] == "Cancelled"
 
+
+def test_void_transaction_with_param(single_transaction_purchase_invoice, auth_client):
+	"""Test if we can void a purchase invoice transaction by passing type into param."""
+	include = {'documentType': 'PurchaseInvoice'}
+	result = auth_client.void_transaction('DEFAULT', single_transaction_purchase_invoice, {'code':'DocVoided'}, include).json()
+	assert result['status'] == "Cancelled"
 


### PR DESCRIPTION
- Integrated PyPI deployment into Travis, will deploy on master after a successful build
- Integrated build notification with Slack, will notify #sdk-development if the build failed on master.

Also included changes from the previous test construction

- corrected certain unit tests to adjust with generated methods removed default param testing since generated method do not include default model.
- added basic workflow functional test case to simulate the lifecycle of a transaction and ensure all related method works.
- allowed the client to input either pair of sandbox credential for testing(code will choose based on availability in env)
- added more conf-test fixtures for other test cases to use.
- renamed testing credentials with SANDBOX_ prefix to avoid conflict with existing USERNAME that exists in certain development env. (more explicitly too)

All tests pass locally