### PR TITLE
Remove IPython dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6'
     ],
-    install_requires=['requests', 'ipython'],
+    install_requires=['requests'],
     extras_require={
         "test": ['pytest', 'pytest-cov', 'tox']
     })


### PR DESCRIPTION
IPython doesn't really make sense as a dependency. While it may be useful for development as an improved REPL, it's not actually used by this package, and doesn't in general make sense to add to applications using this API.