### PR TITLE
Enable setting the $include query parameter on transaction creation

### DIFF
--- a/src/transaction_builder_methods.py
+++ b/src/transaction_builder_methods.py
@@ -241,13 +241,12 @@ class Mixin:
             raise Exception('No lines have been added. The {} method applies to the most recent line. To use this function, first add a line.'.format(member_name))
         return line[-1]
 
-    def create(self):
+    def create(self, include=None):
         """
         Create this transaction.
 
         :return: TransactionModel
         """
-        include = None
         return self.client.create_transaction(self.create_model, include)
 
     def with_line_tax_override(self, type_, reason, tax_amount, tax_date):


### PR DESCRIPTION
Hi @contygm I found an issue with creating transactions while developing against avalra with this sdk.

The client function create_transaction allows setting of the $include query
parameter. When using the transaction builders create function its not possible
to set this variable. This change allows setting of the variable while keeping
backwards compatibility with the previous implementation.