### PR TITLE
Update Postal Code parameter to match API

### DIFF
--- a/src/avalara/transaction_builder_methods.py
+++ b/src/avalara/transaction_builder_methods.py
@@ -78,7 +78,7 @@ class Mixin:
                             of the location.
             city          City of the location.
             region        State or Region of the location.
-            postal_code    Postal/zip code of the location.
+            postalCode    Postal/zip code of the location.
             country       The two-letter country code of the location.
         :return: TransactionBuilder
         """
@@ -101,7 +101,7 @@ class Mixin:
                             of the location.
             city          City of the location.
             region        State or Region of the location.
-            postal_code    Postal/zip code of the location.
+            postalCode    Postal/zip code of the location.
             country       The two-letter country code of the location.
         :return: TransactionBuilder
         """
@@ -313,7 +313,7 @@ class Mixin:
                             of the location.
             city          City of the location.
             region        State or Region of the location.
-            postal_code    Postal/zip code of the location.
+            postalCode    Postal/zip code of the location.
             country       The two-letter country code of the location.
         :return: TransactionBuilder
         """


### PR DESCRIPTION
The address methods list the Postal Code parameter as `postal_code` however the Avalara API accepts only `postalCode`. This PR resolves this discrepancy so that developers using this and its SDK can successfully create transactions.