### PR TITLE
PR : AS-147 : Added logging to Python V2 SDK

### DIFF
--- a/src/avalara/ava_logger.py
+++ b/src/avalara/ava_logger.py
@@ -1,0 +1,86 @@
+import functools
+import logging
+import json
+import requests
+import avalara.client
+
+# set basic configuration for logging framework
+logging.basicConfig(level=logging.INFO,
+                    format="\n%(asctime)s %(levelname)s Avalara_sdk_Log : %(message)s",
+                    datefmt="%m-%d-%Y %I:%M:%S %p %Z")
+
+
+def ava_log(func):
+    """
+    Function decorator for implementation of logging
+    @param func: function where logging needs to be implemented
+    @return: function
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        logger = logging.getLogger()
+        is_log_req_resp_allowed = False
+        ava_log_entry = {}
+        is_error_log = False
+
+        # Logic :
+        # 1) Check if decorator is called for function in AvaTaxClient class
+        # 2) If logger is set then use it else use new instance of logger (this property is useful when SDK consumer
+        #    wants to use specific configuration)
+        # 3) Execute actual method and create log entry in case of http response only
+        # 4) In case of exception though log error
+        try:
+            if isinstance(args[0], avalara.client.AvataxClient):
+                if hasattr(args[0], "logger") and (args[0].__getattribute__("logger") is not None):
+                    logger = args[0].__getattribute__("logger")
+                if hasattr(args[0], "is_log_req_resp_allowed"):
+                    is_log_req_resp_allowed = args[0].__getattribute__("is_log_req_resp_allowed")
+            result = func(*args, **kwargs)
+            if result is not None and isinstance(result, requests.models.Response):
+                ava_log_entry = get_ava_log_entry(result, is_log_req_resp_allowed)
+            return result
+        except Exception as e:
+            is_error_log = True
+            ava_log_entry["error"] = str(e)
+            raise e
+        finally:
+            json_data = json.dumps(ava_log_entry, indent=4)
+            if is_error_log:
+                logger.error(json_data)
+            else:
+                logger.info(json_data)
+
+    return wrapper
+
+
+def get_ava_log_entry(result: requests.Response, is_log_req_resp_allowed: bool) -> dict:
+    log_entry = {}
+    log_entry["execution_time"] = result.elapsed.total_seconds() * 1000
+    log_entry["x-correlation-id"] = result.headers["x-correlation-id"]
+    log_entry["status_code"] = result.status_code
+    log_entry["request_url"] = result.url
+    log_entry["method"] = result.request.method
+    if is_log_req_resp_allowed:
+        log_entry["request"] = str(result.request.body)
+        log_entry["response"] = result.text
+
+    return log_entry
+
+
+def decorate_all_methods(decorator, exclude=["__init__", "add_credentials"]):
+    """
+    Decorator to be applied at class level. This decorator decorates all methods in class with
+    supplied decorator in parameter.
+    @param decorator: decorator to be applied to all methods in class
+    @param exclude: list of methods to exclude from being decorated.
+    @return: class with decorated methods
+    """
+
+    def decorate(cls):
+        for attr in cls.__dict__:
+            if callable(getattr(cls, attr)) and attr not in exclude:
+                setattr(cls, attr, decorator(getattr(cls, attr)))
+        return cls
+
+    return decorate

--- a/src/avalara/client.py
+++ b/src/avalara/client.py
@@ -24,17 +24,27 @@ AvaTax Software Development Kit for Python.
 @version    TBD
 @link       https://github.com/avadev/AvaTax-REST-V2-Python-SDK
 """
+
 from requests.auth import HTTPBasicAuth
-from ._str_version import str_type
+
 from . import client_methods
-import os
+from ._str_version import str_type
+from .ava_logger import ava_log, decorate_all_methods
 
 
+@decorate_all_methods(ava_log)  # class decorator to implement logging
 class AvataxClient(client_methods.Mixin):
     """Class for our Avatax client."""
 
-    def __init__(self, app_name=None, app_version=None, machine_name=None,
-                 environment=None, timeout_limit=None):
+    def __init__(
+            self,
+            app_name=None,
+            app_version=None,
+            machine_name=None,
+            environment=None,
+            timeout_limit=None,
+            is_log_req_resp_allowed=False
+    ):
         """
         Initialize the sandbox client.
 
@@ -47,11 +57,13 @@ class AvataxClient(client_methods.Mixin):
             :param  string  environment: Default environment is production,
                 input sandbox, for the sandbox API
             :param  int/float The timeout limit for every call made by this client instance. (default: 10 sec)
+            :param  bool is_log_req_resp_allowed: is logging request and response is allowed (default: False)
         :return: object
         """
-        if not all(isinstance(i, str_type) for i in [app_name,
-                                                     machine_name,
-                                                     environment]):
+        if not all(
+                isinstance(i, str_type)
+                for i in [app_name, machine_name, environment]
+        ):
             raise ValueError('Input(s) must be string or none type object')
         self.base_url = 'https://rest.avatax.com'
         if environment:
@@ -63,11 +75,16 @@ class AvataxClient(client_methods.Mixin):
         self.app_name = app_name
         self.app_version = app_version
         self.machine_name = machine_name
-        self.client_id = '{}; {}; Python SDK; API_VERSION; {};'.format(app_name,
-                                                                app_version,
-                                                                machine_name)
+        self.client_id = '{}; {}; Python SDK; API_VERSION; {};'.format(
+            app_name, app_version, machine_name
+        )
         self.client_header = {'X-Avalara-Client': self.client_id}
-        self.timeout_limit = timeout_limit 
+        self.timeout_limit = timeout_limit
+        self.is_log_req_resp_allowed = is_log_req_resp_allowed
+        self.logger = None
+        # if self.logger is set, logging is done using supplied logger configuration
+        # if not set, logging is done using basic configuration
+
 
     def add_credentials(self, username=None, password=None):
         """

--- a/src/avalara/client_methods.py
+++ b/src/avalara/client_methods.py
@@ -1,6 +1,9 @@
 import requests
-from ._str_version import str_type
 
+from avalara.ava_logger import decorate_all_methods, ava_log
+
+
+@decorate_all_methods(ava_log)  # class decorator to implement logging
 class Mixin:
     """Mixin class contain methods attached to Client class."""
 
@@ -26,12 +29,20 @@ class Mixin:
       :param model [ResetLicenseKeyModel] A request confirming that you wish to reset the license key of this account.
       :return LicenseKeyModel
     """
+
     def account_reset_license_key(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/resetlicensekey'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/resetlicensekey'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -51,12 +62,20 @@ class Mixin:
       :param model [ActivateAccountModel] The activation request
       :return AccountModel
     """
+
     def activate_account(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/activate'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/activate'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -82,12 +101,20 @@ class Mixin:
       :param skip [int] If nonzero, skip this number of results before returning data. Used with `$top` to provide pagination for large datasets.
       :return FetchResult
     """
+
     def audit_account(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/audit'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/audit'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -107,12 +134,20 @@ class Mixin:
       :param model [AccountLicenseKeyModel] 
       :return LicenseKeyModel
     """
+
     def create_license_key(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/licensekey'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/licensekey'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -128,12 +163,22 @@ class Mixin:
       :param licensekeyname [string] The license key name you wish to update.
       :return ErrorDetail
     """
+
     def delete_license_key(self, id_, licensekeyname):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/accounts/{}/licensekey/{}'.format(self.base_url, id_, licensekeyname),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/accounts/{}/licensekey/{}'.format(
+                self.base_url, id_, licensekeyname
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -150,12 +195,20 @@ class Mixin:
       :param include [string] A comma separated list of special fetch options
       :return AccountModel
     """
+
     def get_account(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -176,12 +229,20 @@ class Mixin:
       :param id_ [int] 
       :return AccountConfigurationModel
     """
+
     def get_account_configuration(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/configuration'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/configuration'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -194,12 +255,22 @@ class Mixin:
       :param licensekeyname [string] The ID of the account to retrieve
       :return AccountLicenseKeyModel
     """
+
     def get_license_key(self, id_, licensekeyname):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/licensekey/{}'.format(self.base_url, id_, licensekeyname),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/licensekey/{}'.format(
+                self.base_url, id_, licensekeyname
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -212,12 +283,20 @@ class Mixin:
       :param id_ [int] The ID of the account to retrieve
       :return AccountLicenseKeyModel
     """
+
     def get_license_keys(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/licensekeys'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/licensekeys'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -241,12 +320,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_accounts(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -268,12 +355,20 @@ class Mixin:
       :param model [AccountConfigurationModel] 
       :return AccountConfigurationModel
     """
+
     def set_account_configuration(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/configuration'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/configuration'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -303,12 +398,20 @@ class Mixin:
       :param textCase [TextCase] selectable text case for address validation (See TextCase::* for a list of allowable values)
       :return AddressResolutionModel
     """
+
     def resolve_address(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/addresses/resolve'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/addresses/resolve'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -327,12 +430,20 @@ class Mixin:
       :param model [AddressValidationInfo] The address to resolve
       :return AddressResolutionModel
     """
+
     def resolve_address_post(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/addresses/resolve'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/addresses/resolve'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -345,12 +456,22 @@ class Mixin:
       :param model [AdvancedRuleLookupFileModel] The lookup file you wish to create
       :return AdvancedRuleLookupFileModel
     """
+
     def create_company_lookup_file(self, accountId, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/advancedrules/accounts/{}/companies/{}/lookupFiles'.format(self.base_url, accountId, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/advancedrules/accounts/{}/companies/{}/lookupFiles'.format(
+                self.base_url, accountId, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -362,12 +483,22 @@ class Mixin:
       :param id_ [string] The unique ID/GUID for the company lookup file to be deleted
       :return ErrorDetail
     """
+
     def delete_lookup_file(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -379,12 +510,22 @@ class Mixin:
       :param companyId [int] The ID of the company for which to retrieve lookup files
       :return FetchResult
     """
+
     def get_company_lookup_files(self, accountId, companyId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/advancedrules/accounts/{}/companies/{}/lookupFiles'.format(self.base_url, accountId, companyId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/advancedrules/accounts/{}/companies/{}/lookupFiles'.format(
+                self.base_url, accountId, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -396,12 +537,22 @@ class Mixin:
       :param id_ [string] The unique ID/GUID of the company lookup file to return
       :return AdvancedRuleLookupFileModel
     """
+
     def get_lookup_file(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -414,12 +565,22 @@ class Mixin:
       :param model [AdvancedRuleLookupFileModel] The new values to update the lookup file
       :return AdvancedRuleLookupFileModel
     """
+
     def update_lookup_file(self, accountId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/advancedrules/accounts/{}/lookupFiles/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -434,12 +595,20 @@ class Mixin:
       :param model [AvaFileFormModel] The AvaFileForm you wish to create.
       :return AvaFileFormModel
     """
+
     def create_ava_file_forms(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/avafileforms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/avafileforms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -453,12 +622,20 @@ class Mixin:
       :param id_ [int] The ID of the AvaFileForm you wish to delete.
       :return ErrorDetail
     """
+
     def delete_ava_file_form(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -472,12 +649,20 @@ class Mixin:
       :param id_ [int] The primary key of this AvaFileForm
       :return AvaFileFormModel
     """
+
     def get_ava_file_form(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -495,12 +680,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_ava_file_forms(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/avafileforms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/avafileforms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -516,12 +709,20 @@ class Mixin:
       :param model [AvaFileFormModel] The AvaFileForm model you wish to update.
       :return AvaFileFormModel
     """
+
     def update_ava_file_form(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/avafileforms/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -543,12 +744,22 @@ class Mixin:
       :param id_ [int] The ID of the batch to cancel.
       :return BatchModel
     """
+
     def cancel_batch(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/batches/{}/cancel'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/batches/{}/cancel'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -576,12 +787,20 @@ class Mixin:
       :param model [BatchModel] The batch you wish to create.
       :return BatchModel
     """
+
     def create_batches(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/batches'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/batches'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -608,12 +827,22 @@ class Mixin:
       :param model [CreateTransactionBatchRequestModel] The transaction batch you wish to create.
       :return CreateTransactionBatchResponseModel
     """
+
     def create_transaction_batch(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/batches/transactions'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/batches/transactions'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -634,12 +863,22 @@ class Mixin:
       :param id_ [int] The ID of the batch to delete.
       :return ErrorDetail
     """
+
     def delete_batch(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/batches/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/batches/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -654,12 +893,22 @@ class Mixin:
       :param id_ [int] The primary key of this batch file object
       :return String
     """
+
     def download_batch(self, companyId, batchId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/batches/{}/files/{}/attachment'.format(self.base_url, companyId, batchId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/batches/{}/files/{}/attachment'.format(
+                self.base_url, companyId, batchId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -684,12 +933,22 @@ class Mixin:
       :param id_ [int] The primary key of this batch
       :return BatchModel
     """
+
     def get_batch(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/batches/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/batches/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -722,12 +981,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_batches_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/batches'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/batches'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -757,12 +1024,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_batches(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/batches'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/batches'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -789,12 +1064,22 @@ class Mixin:
       :param model [CreateCertExpressInvitationModel] the requests to send out to customers
       :return CertExpressInvitationStatusModel
     """
+
     def create_cert_express_invitation(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/customers/{}/certexpressinvites'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/customers/{}/certexpressinvites'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -822,12 +1107,24 @@ class Mixin:
       :param include [string] OPTIONAL: A comma separated list of special fetch options. No options are defined at this time.
       :return CertExpressInvitationModel
     """
-    def get_cert_express_invitation(self, companyId, customerCode, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers/{}/certexpressinvites/{}'.format(self.base_url, companyId, customerCode, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def get_cert_express_invitation(
+            self, companyId, customerCode, id_, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers/{}/certexpressinvites/{}'.format(
+                self.base_url, companyId, customerCode, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -857,12 +1154,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_cert_express_invitations(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certexpressinvites'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certexpressinvites'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -893,12 +1200,23 @@ class Mixin:
       :param model [CertificateModel] Certificates to be created
       :return CertificateModel
     """
+
     def create_certificates(self, companyId, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -922,12 +1240,22 @@ class Mixin:
       :param id_ [int] The unique ID number of this certificate
       :return ErrorDetail
     """
+
     def delete_certificate(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/certificates/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/certificates/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -954,12 +1282,22 @@ class Mixin:
       :param type [CertificatePreviewType] The data format in which to retrieve the certificate image (See CertificatePreviewType::* for a list of allowable values)
       :return String
     """
+
     def download_certificate_image(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates/{}/attachment'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates/{}/attachment'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -987,12 +1325,22 @@ class Mixin:
       :param include [string] OPTIONAL: A comma separated list of special fetch options. You can specify one or more of the following:      * customers - Retrieves the list of customers linked to the certificate.   * po_numbers - Retrieves all PO numbers tied to the certificate.   * attributes - Retrieves all attributes applied to the certificate.
       :return CertificateModel
     """
+
     def get_certificate(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1011,12 +1359,22 @@ class Mixin:
       :param companyId [int] The company ID to check
       :return ProvisionStatusModel
     """
+
     def get_certificate_setup(self, companyId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates/setup'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates/setup'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1042,12 +1400,22 @@ class Mixin:
       :param model [CertificateAttributeModel] The list of attributes to link to this certificate.
       :return FetchResult
     """
+
     def link_attributes_to_certificate(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/{}/attributes/link'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/{}/attributes/link'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1074,12 +1442,22 @@ class Mixin:
       :param model [LinkCustomersModel] The list of customers needed be added to the Certificate for exemption
       :return FetchResult
     """
+
     def link_customers_to_certificate(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/{}/customers/link'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/{}/customers/link'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1104,12 +1482,22 @@ class Mixin:
       :param id_ [int] The unique ID number of this certificate
       :return FetchResult
     """
+
     def list_attributes_for_certificate(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates/{}/attributes'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates/{}/attributes'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1135,12 +1523,22 @@ class Mixin:
       :param include [string] OPTIONAL: A comma separated list of special fetch options.   No options are currently available when fetching customers.
       :return FetchResult
     """
+
     def list_customers_for_certificate(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates/{}/customers'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates/{}/customers'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1171,12 +1569,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_certificates(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certificates'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certificates'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1196,12 +1604,22 @@ class Mixin:
       :param companyId [int] 
       :return ProvisionStatusModel
     """
+
     def request_certificate_setup(self, companyId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/setup'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/setup'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1227,12 +1645,22 @@ class Mixin:
       :param model [CertificateAttributeModel] The list of attributes to unlink from this certificate.
       :return FetchResult
     """
+
     def unlink_attributes_from_certificate(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/{}/attributes/unlink'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/{}/attributes/unlink'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1260,12 +1688,22 @@ class Mixin:
       :param model [LinkCustomersModel] The list of customers to unlink from this certificate
       :return FetchResult
     """
+
     def unlink_customers_from_certificate(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/{}/customers/unlink'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/{}/customers/unlink'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1289,12 +1727,22 @@ class Mixin:
       :param model [CertificateModel] The new certificate object that will replace the existing one
       :return CertificateModel
     """
+
     def update_certificate(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/certificates/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/certificates/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1320,12 +1768,22 @@ class Mixin:
       :param file [String] The exemption certificate file you wanted to upload. Accepted formats are: PDF, JPEG, TIFF, PNG.
       :return string
     """
+
     def upload_certificate_image(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/certificates/{}/attachment'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/certificates/{}/attachment'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1359,12 +1817,20 @@ class Mixin:
       :param id_ [int] The ID of the company to check if its integration is certified.
       :return string
     """
+
     def certify_integration(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/certify'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/certify'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1386,12 +1852,20 @@ class Mixin:
       :param model [FilingStatusChangeModel] 
       :return string
     """
+
     def change_filing_status(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/filingstatus'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/filingstatus'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1413,12 +1887,20 @@ class Mixin:
       :param model [CompanyInitializationModel] Information about the company you wish to create.
       :return CompanyModel
     """
+
     def company_initialize(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/initialize'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/initialize'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1434,12 +1916,20 @@ class Mixin:
       :param model [CompanyModel] Either a single company object or an array of companies to create
       :return CompanyModel
     """
+
     def create_companies(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1458,12 +1948,22 @@ class Mixin:
       :param model [CompanyParameterDetailModel] The company parameters you wish to create.
       :return CompanyParameterDetailModel
     """
+
     def create_company_parameters(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/parameters'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/parameters'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1489,12 +1989,21 @@ class Mixin:
       :param model [FundingInitiateModel] The funding initialization request
       :return FundingStatusModel
     """
+
     def create_funding_request(self, id_, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/funding/setup'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/funding/setup'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1507,12 +2016,20 @@ class Mixin:
       :param id_ [int] The ID of the company you wish to delete.
       :return ErrorDetail
     """
+
     def delete_company(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1529,12 +2046,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return ErrorDetail
     """
+
     def delete_company_parameter(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/parameters/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/parameters/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1551,12 +2078,22 @@ class Mixin:
       :param companyId [int] The unique identifier of the company
       :return FundingConfigurationModel
     """
+
     def funding_configuration_by_company(self, companyId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/funding/configuration'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/funding/configuration'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1574,12 +2111,24 @@ class Mixin:
       :param currency [string] The currency of the funding. USD and CAD are the only valid currencies
       :return FundingConfigurationModel
     """
-    def funding_configurations_by_company_and_currency(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/funding/configurations'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def funding_configurations_by_company_and_currency(
+            self, companyId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/funding/configurations'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1604,12 +2153,20 @@ class Mixin:
       :param include [string] OPTIONAL: A comma separated list of special fetch options.      * Child objects - Specify one or more of the following to retrieve objects related to each company: "Contacts", "FilingCalendars", "Items", "Locations", "Nexus", "TaxCodes", "NonReportingChildren" or "TaxRules".   * Deleted objects - Specify "FetchDeleted" to retrieve information about previously deleted objects.
       :return CompanyModel
     """
+
     def get_company(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1630,12 +2187,20 @@ class Mixin:
       :param id_ [int] 
       :return CompanyConfigurationModel
     """
+
     def get_company_configuration(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/configuration'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/configuration'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1652,12 +2217,22 @@ class Mixin:
       :param id_ [int] 
       :return CompanyParameterDetailModel
     """
+
     def get_company_parameter_detail(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/parameters/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/parameters/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1680,12 +2255,20 @@ class Mixin:
       :param id_ [int] 
       :return string
     """
+
     def get_filing_status(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/filingstatus'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/filingstatus'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1704,12 +2287,24 @@ class Mixin:
       :param periodmonth [int] The period month
       :return ACHEntryDetailModel
     """
-    def list_a_c_h_entry_details_for_company(self, id_, periodyear, periodmonth):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/paymentdetails/{}/{}'.format(self.base_url, id_, periodyear, periodmonth),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_a_c_h_entry_details_for_company(
+            self, id_, periodyear, periodmonth
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/paymentdetails/{}/{}'.format(
+                self.base_url, id_, periodyear, periodmonth
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1731,12 +2326,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_company_parameter_details(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/parameters'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/parameters'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1753,12 +2358,20 @@ class Mixin:
       :param id_ [int] The unique identifier of the company
       :return FundingStatusModel
     """
+
     def list_funding_requests_by_company(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/funding'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/funding'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1771,12 +2384,20 @@ class Mixin:
     
       :return FetchResult
     """
+
     def list_mrs_companies(self):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/mrs'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/mrs'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1806,12 +2427,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_companies(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1833,12 +2462,20 @@ class Mixin:
       :param model [CompanyConfigurationModel] 
       :return CompanyConfigurationModel
     """
+
     def set_company_configuration(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/configuration'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/configuration'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1858,12 +2495,20 @@ class Mixin:
       :param model [CompanyModel] The company object you wish to update.
       :return CompanyModel
     """
+
     def update_company(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1881,12 +2526,22 @@ class Mixin:
       :param model [CompanyParameterDetailModel] The company parameter object you wish to update.
       :return CompanyParameterDetailModel
     """
+
     def update_company_parameter_detail(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/parameters/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/parameters/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1906,12 +2561,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return ComplianceJurisdictionRateModel
     """
+
     def query_tax_authority_jurisdiction_rates(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/compliance/taxauthorityjurisdictionrates'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/compliance/taxauthorityjurisdictionrates'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1927,12 +2592,20 @@ class Mixin:
       :param model [ContactModel] The contacts you wish to create.
       :return ContactModel
     """
+
     def create_contacts(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/contacts'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/contacts'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1946,12 +2619,22 @@ class Mixin:
       :param id_ [int] The ID of the contact you wish to delete.
       :return ErrorDetail
     """
+
     def delete_contact(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/contacts/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/contacts/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1967,12 +2650,22 @@ class Mixin:
       :param id_ [int] The primary key of this contact
       :return ContactModel
     """
+
     def get_contact(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/contacts/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/contacts/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -1991,12 +2684,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_contacts_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/contacts'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/contacts'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2016,12 +2717,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_contacts(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/contacts'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/contacts'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2040,12 +2749,22 @@ class Mixin:
       :param model [ContactModel] The contact you wish to update.
       :return ContactModel
     """
+
     def update_contact(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/contacts/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/contacts/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2071,12 +2790,22 @@ class Mixin:
       :param model [CustomerModel] The list of customer objects to be created
       :return CustomerModel
     """
+
     def create_customers(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/customers'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/customers'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2100,12 +2829,22 @@ class Mixin:
       :param customerCode [string] The unique code representing this customer
       :return CustomerModel
     """
+
     def delete_customer(self, companyId, customerCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/customers/{}'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/customers/{}'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2134,12 +2873,22 @@ class Mixin:
       :param include [string] Specify optional additional objects to include in this fetch request
       :return CustomerModel
     """
+
     def get_customer(self, companyId, customerCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers/{}'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers/{}'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2166,12 +2915,22 @@ class Mixin:
       :param model [CustomerAttributeModel] The list of attributes to link to the customer.
       :return FetchResult
     """
+
     def link_attributes_to_customer(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/customers/{}/attributes/link'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/customers/{}/attributes/link'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2196,12 +2955,22 @@ class Mixin:
       :param model [LinkCertificatesModel] The list of certificates to link to this customer
       :return FetchResult
     """
+
     def link_certificates_to_customer(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/customers/{}/certificates/link'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/customers/{}/certificates/link'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2226,12 +2995,22 @@ class Mixin:
       :param model [LinkCustomersModel] A list of information about ship-to customers to link to this bill-to customer.
       :return CustomerModel
     """
+
     def link_ship_to_customers_to_bill_customer(self, companyId, code, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/customers/billto/{}/shipto/link'.format(self.base_url, companyId, code),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/customers/billto/{}/shipto/link'.format(
+                self.base_url, companyId, code
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2257,12 +3036,22 @@ class Mixin:
       :param customerCode [string] The unique code representing the current customer
       :return FetchResult
     """
+
     def list_attributes_for_customer(self, companyId, customerCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers/{}/attributes'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers/{}/attributes'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2291,12 +3080,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_certificates_for_customer(self, companyId, customerCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers/{}/certificates'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_certificates_for_customer(
+            self, companyId, customerCode, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers/{}/certificates'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2324,12 +3125,24 @@ class Mixin:
       :param region [string] Search for certificates matching this region. Uses the ISO 3166 two or three character state, region, or province code.
       :return ExemptionStatusModel
     """
-    def list_valid_certificates_for_customer(self, companyId, customerCode, country, region):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers/{}/certificates/{}/{}'.format(self.base_url, companyId, customerCode, country, region),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_valid_certificates_for_customer(
+            self, companyId, customerCode, country, region
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers/{}/certificates/{}/{}'.format(
+                self.base_url, companyId, customerCode, country, region
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2360,12 +3173,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_customers(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/customers'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/customers'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2392,12 +3215,22 @@ class Mixin:
       :param model [CustomerAttributeModel] The list of attributes to unlink from the customer.
       :return FetchResult
     """
+
     def unlink_attributes_from_customer(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/customers/{}/attributes/unlink'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/customers/{}/attributes/unlink'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2422,12 +3255,24 @@ class Mixin:
       :param model [LinkCertificatesModel] The list of certificates to link to this customer
       :return FetchResult
     """
-    def unlink_certificates_from_customer(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/customers/{}/certificates/unlink'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def unlink_certificates_from_customer(
+            self, companyId, customerCode, model
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/customers/{}/certificates/unlink'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2452,12 +3297,22 @@ class Mixin:
       :param model [CustomerModel] The new customer model that will replace the existing record at this URL
       :return CustomerModel
     """
+
     def update_customer(self, companyId, customerCode, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/customers/{}'.format(self.base_url, companyId, customerCode),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/customers/{}'.format(
+                self.base_url, companyId, customerCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2472,12 +3327,22 @@ class Mixin:
       :param model [DataSourceModel] 
       :return DataSourceModel
     """
+
     def create_data_sources(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/datasources'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/datasources'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2492,12 +3357,22 @@ class Mixin:
       :param id_ [int] The id of the datasource you wish to delete.
       :return ErrorDetail
     """
+
     def delete_data_source(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/datasources/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/datasources/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2512,12 +3387,22 @@ class Mixin:
       :param id_ [int] data source id
       :return DataSourceModel
     """
+
     def get_data_source_by_id(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/datasources/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/datasources/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2535,12 +3420,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_data_sources(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/datasources'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/datasources'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2559,12 +3454,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_data_sources(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/datasources'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/datasources'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2580,12 +3483,22 @@ class Mixin:
       :param model [DataSourceModel] 
       :return DataSourceModel
     """
+
     def update_data_source(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/datasources/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/datasources/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2605,12 +3518,22 @@ class Mixin:
       :param hsCode [string] The partial or full HS Code for which you would like to view all of the parents.
       :return FetchResult
     """
+
     def get_cross_border_code(self, country, hsCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/crossborder/{}/{}/hierarchy'.format(self.base_url, country, hsCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/crossborder/{}/{}/hierarchy'.format(
+                self.base_url, country, hsCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2626,12 +3549,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def get_login_verifier_by_form(self, form, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/filingcalendars/loginverifiers/{}'.format(self.base_url, form),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/filingcalendars/loginverifiers/{}'.format(
+                self.base_url, form
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2645,12 +3578,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_all_marketplace_locations(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/listallmarketplacelocations'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/listallmarketplacelocations'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2667,12 +3610,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_ava_file_forms(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/avafileforms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/avafileforms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2691,12 +3642,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_certificate_attributes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/certificateattributes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/certificateattributes'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2714,12 +3675,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_certificate_exempt_reasons(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/certificateexemptreasons'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/certificateexemptreasons'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2737,12 +3708,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_certificate_exposure_zones(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/certificateexposurezones'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/certificateexposurezones'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2758,12 +3739,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_classification_parameters_usage(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/classification/parametersusage'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/classification/parametersusage'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2778,12 +3769,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_communications_service_types(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/communications/transactiontypes/{}/servicetypes'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/communications/transactiontypes/{}/servicetypes'.format(
+                self.base_url, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2798,12 +3799,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_communications_transaction_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/communications/transactiontypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/communications/transactiontypes'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2818,12 +3829,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_communications_t_s_pairs(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/communications/tspairs'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/communications/tspairs'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2839,12 +3860,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_countries(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/countries'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/countries'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2863,12 +3892,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_cover_letters(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/coverletters'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/coverletters'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2891,12 +3928,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_cross_border_codes(self, country, hsCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/crossborder/{}/{}'.format(self.base_url, country, hsCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/crossborder/{}/{}'.format(
+                self.base_url, country, hsCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2912,12 +3959,20 @@ class Mixin:
     
       :return FetchResult
     """
+
     def list_cross_border_sections(self):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/crossborder/sections'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/crossborder/sections'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2933,12 +3988,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_currencies(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/currencies'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/currencies'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2956,12 +4019,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_entity_use_codes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/entityusecodes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/entityusecodes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2976,12 +4047,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_filing_frequencies(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/filingfrequencies'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/filingfrequencies'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -2998,12 +4077,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_jurisdictions(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/jurisdictions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/jurisdictions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3028,12 +4115,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_jurisdictions_by_address(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/jurisdictionsnearaddress'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/jurisdictionsnearaddress'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3056,12 +4153,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_jurisdictions_by_rate_type_tax_type_mapping(self, country, taxTypeId, taxSubTypeId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/jurisdictions/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(self.base_url, country, taxTypeId, taxSubTypeId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_jurisdictions_by_rate_type_tax_type_mapping(
+            self, country, taxTypeId, taxSubTypeId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/jurisdictions/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(
+                self.base_url, country, taxTypeId, taxSubTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3075,12 +4184,24 @@ class Mixin:
       :param rateTypeId [string] The ratetype for which you want to retrieve the jurisdiction information
       :return string
     """
-    def list_jurisdiction_types_by_rate_type_tax_type_mapping(self, country, taxTypeId, taxSubTypeId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/jurisdictionTypes/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(self.base_url, country, taxTypeId, taxSubTypeId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_jurisdiction_types_by_rate_type_tax_type_mapping(
+            self, country, taxTypeId, taxSubTypeId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/jurisdictionTypes/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(
+                self.base_url, country, taxTypeId, taxSubTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3108,12 +4229,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_location_questions_by_address(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/locationquestions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/locationquestions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3129,12 +4258,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_login_verifiers(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/filingcalendars/loginverifiers'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/filingcalendars/loginverifiers'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3148,12 +4287,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_marketplace_locations(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/marketplacelocations'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/marketplacelocations'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3168,12 +4315,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3198,12 +4353,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_by_address(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus/byaddress'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus/byaddress'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3219,12 +4382,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_by_country(self, country, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus/{}'.format(self.base_url, country),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus/{}'.format(self.base_url, country),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3241,12 +4412,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_by_country_and_region(self, country, region, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus/{}/{}'.format(self.base_url, country, region),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus/{}/{}'.format(
+                self.base_url, country, region
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3266,12 +4447,22 @@ class Mixin:
       :param formCode [string] The form code that we are looking up the nexus for
       :return NexusByTaxFormModel
     """
+
     def list_nexus_by_form_code(self, formCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus/byform/{}'.format(self.base_url, formCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus/byform/{}'.format(
+                self.base_url, formCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3287,12 +4478,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_by_tax_type_group(self, taxTypeGroup, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexus/bytaxtypegroup/{}'.format(self.base_url, taxTypeGroup),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexus/bytaxtypegroup/{}'.format(
+                self.base_url, taxTypeGroup
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3307,12 +4508,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_tax_type_groups(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/nexustaxtypegroups'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/nexustaxtypegroups'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3327,12 +4536,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_customer_funding_options(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticecustomerfundingoptions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticecustomerfundingoptions'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3347,12 +4566,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_customer_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticecustomertypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticecustomertypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3367,12 +4594,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_filingtypes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticefilingtypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticefilingtypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3387,12 +4622,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_priorities(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticepriorities'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticepriorities'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3407,12 +4650,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_reasons(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticereasons'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticereasons'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3427,12 +4678,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_responsibilities(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticeresponsibilities'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticeresponsibilities'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3447,12 +4708,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_root_causes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticerootcauses'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticerootcauses'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3467,12 +4736,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_statuses(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticestatuses'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticestatuses'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3487,12 +4764,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notice_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/noticetypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/noticetypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3508,12 +4793,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_parameters(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/parameters'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/parameters'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3542,12 +4835,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_parameters_by_item(self, companyCode, itemCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/parameters/byitem/{}/{}'.format(self.base_url, companyCode, itemCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/parameters/byitem/{}/{}'.format(
+                self.base_url, companyCode, itemCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3563,12 +4866,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_parameters_usage(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/parametersusage'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/parametersusage'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3581,12 +4892,20 @@ class Mixin:
       :param skip [int] If nonzero, skip this number of results before returning data. Used with `$top` to provide pagination for large datasets.
       :return FetchResult
     """
+
     def list_permissions(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/permissions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/permissions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3600,12 +4919,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_postal_codes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/postalcodes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/postalcodes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3625,12 +4952,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_preferred_programs(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/preferredprograms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/preferredprograms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3647,12 +4982,22 @@ class Mixin:
       :param countryCode [string] If not null, return all records with this code.
       :return FetchResult
     """
+
     def list_product_classification_systems(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/productclassificationsystems'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/productclassificationsystems'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3676,12 +5021,24 @@ class Mixin:
       :param countryCode [string] If not null, return all records with this code.
       :return FetchResult
     """
-    def list_product_classification_systems_by_company(self, companyCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/productclassificationsystems/bycompany/{}'.format(self.base_url, companyCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_product_classification_systems_by_company(
+            self, companyCode, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/productclassificationsystems/bycompany/{}'.format(
+                self.base_url, companyCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3697,12 +5054,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_rate_types_by_country(self, country, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/countries/{}/ratetypes'.format(self.base_url, country),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/countries/{}/ratetypes'.format(
+                self.base_url, country
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3720,12 +5087,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_rate_types_by_country_tax_type_tax_sub_type(self, country, taxTypeId, taxSubTypeId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/countries/{}/taxtypes/{}/taxsubtypes/{}/ratetypes'.format(self.base_url, country, taxTypeId, taxSubTypeId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_rate_types_by_country_tax_type_tax_sub_type(
+            self, country, taxTypeId, taxSubTypeId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/countries/{}/taxtypes/{}/taxsubtypes/{}/ratetypes'.format(
+                self.base_url, country, taxTypeId, taxSubTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3741,12 +5120,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_regions(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/regions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/regions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3763,12 +5150,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_regions_by_country(self, country, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/countries/{}/regions'.format(self.base_url, country),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/countries/{}/regions'.format(
+                self.base_url, country
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3783,12 +5180,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_resource_file_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/resourcefiletypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/resourcefiletypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3804,12 +5209,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_returns_parameters_usage(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/returns/parametersusage'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/returns/parametersusage'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3825,12 +5240,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_security_roles(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/securityroles'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/securityroles'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3847,12 +5270,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_subscription_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/subscriptiontypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/subscriptiontypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3866,12 +5297,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tags(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/tags'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/tags'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3886,12 +5325,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_authorities(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxauthorities'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxauthorities'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3908,12 +5355,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_authority_forms(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxauthorityforms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxauthorityforms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3928,12 +5383,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_authority_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxauthoritytypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxauthoritytypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3953,12 +5416,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_codes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxcodes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxcodes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3972,12 +5443,20 @@ class Mixin:
       :param skip [int] If nonzero, skip this number of results before returning data. Used with `$top` to provide pagination for large datasets.
       :return TaxCodeTypesModel
     """
+
     def list_tax_code_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxcodetypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxcodetypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -3992,12 +5471,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_forms(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxforms'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxforms'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4012,12 +5499,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_sub_types(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxsubtypes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxsubtypes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4034,12 +5529,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_tax_sub_types_by_country_and_tax_type(self, country, taxTypeId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxsubtypes/countries/{}/taxtypes/{}'.format(self.base_url, country, taxTypeId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_tax_sub_types_by_country_and_tax_type(
+            self, country, taxTypeId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxsubtypes/countries/{}/taxtypes/{}'.format(
+                self.base_url, country, taxTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4056,12 +5563,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_tax_sub_types_by_jurisdiction_and_region(self, jurisdictionCode, region, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxsubtypes/{}/{}'.format(self.base_url, jurisdictionCode, region),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_tax_sub_types_by_jurisdiction_and_region(
+            self, jurisdictionCode, region, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxsubtypes/{}/{}'.format(
+                self.base_url, jurisdictionCode, region
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4076,12 +5595,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_type_groups(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxtypegroups'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxtypegroups'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4096,12 +5623,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_types_by_nexus_and_country(self, country, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/taxtypes/countries/{}'.format(self.base_url, country),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/taxtypes/countries/{}'.format(
+                self.base_url, country
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4118,12 +5655,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_unit_of_basis_by_country_and_tax_type_and_tax_sub_type_and_rate_type(self, country, taxTypeId, taxSubTypeId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/unitofbasis/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(self.base_url, country, taxTypeId, taxSubTypeId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_unit_of_basis_by_country_and_tax_type_and_tax_sub_type_and_rate_type(
+            self, country, taxTypeId, taxSubTypeId, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/unitofbasis/countries/{}/taxtypes/{}/taxsubtypes/{}'.format(
+                self.base_url, country, taxTypeId, taxSubTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4138,12 +5687,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_unit_of_measurement(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/definitions/unitofmeasurements'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/definitions/unitofmeasurements'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4160,12 +5717,22 @@ class Mixin:
       :param model [CompanyDistanceThresholdModel] The DistanceThreshold object or objects you wish to create.
       :return CompanyDistanceThresholdModel
     """
+
     def create_distance_threshold(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/distancethresholds'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/distancethresholds'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4182,12 +5749,22 @@ class Mixin:
       :param id_ [int] The unique ID number of the DistanceThreshold object you wish to delete.
       :return ErrorDetail
     """
+
     def delete_distance_threshold(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/distancethresholds/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/distancethresholds/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4204,12 +5781,22 @@ class Mixin:
       :param id_ [int] The unique ID number referring to this DistanceThreshold object
       :return CompanyDistanceThresholdModel
     """
+
     def get_distance_threshold(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/distancethresholds/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/distancethresholds/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4230,12 +5817,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_distance_thresholds(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/distancethresholds'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/distancethresholds'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4257,12 +5854,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_distance_thresholds(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/distancethresholds'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/distancethresholds'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4282,12 +5887,22 @@ class Mixin:
       :param model [CompanyDistanceThresholdModel] The new DistanceThreshold object to store.
       :return CompanyDistanceThresholdModel
     """
+
     def update_distance_threshold(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/distancethresholds/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/distancethresholds/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4302,12 +5917,22 @@ class Mixin:
       :param model [CreateECommerceTokenInputModel] 
       :return ECommerceTokenOutputModel
     """
+
     def create_e_commerce_token(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/ecommercetokens'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/ecommercetokens'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4322,12 +5947,22 @@ class Mixin:
       :param model [RefreshECommerceTokenInputModel] 
       :return FetchResult
     """
+
     def refresh_e_commerce_token(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/ecommercetokens'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/ecommercetokens'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4340,12 +5975,22 @@ class Mixin:
       :param id_ [int] 
       :return FirmClientLinkageOutputModel
     """
+
     def approve_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages/{}/approve'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages/{}/approve'.format(
+                self.base_url, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4364,12 +6009,22 @@ class Mixin:
       :param model [NewFirmClientAccountRequestModel] Information about the account you wish to create.
       :return FirmClientLinkageOutputModel
     """
+
     def create_and_link_new_firm_client_account(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages/createandlinkclient'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages/createandlinkclient'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4382,12 +6037,20 @@ class Mixin:
       :param model [FirmClientLinkageInputModel] FirmClientLinkageInputModel
       :return FirmClientLinkageOutputModel
     """
+
     def create_firm_client_linkage(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4400,12 +6063,20 @@ class Mixin:
       :param id_ [int] 
       :return ErrorDetail
     """
+
     def delete_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/firmclientlinkages/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/firmclientlinkages/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4418,12 +6089,20 @@ class Mixin:
       :param id_ [int] 
       :return FirmClientLinkageOutputModel
     """
+
     def get_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/firmclientlinkages/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/firmclientlinkages/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4436,12 +6115,20 @@ class Mixin:
       :param filter [string] A filter statement to identify specific records to retrieve. For more information on filtering, see [Filtering in REST](http://developer.avalara.com/avatax/filtering-in-rest/).<br />*Not filterable:* firmAccountName, clientAccountName
       :return FetchResult
     """
+
     def list_firm_client_linkage(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/firmclientlinkages'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/firmclientlinkages'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4454,12 +6141,22 @@ class Mixin:
       :param id_ [int] 
       :return FirmClientLinkageOutputModel
     """
+
     def reject_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages/{}/reject'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages/{}/reject'.format(
+                self.base_url, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4472,12 +6169,20 @@ class Mixin:
       :param id_ [int] 
       :return FirmClientLinkageOutputModel
     """
+
     def reset_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages/{}/reset'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages/{}/reset'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4490,12 +6195,22 @@ class Mixin:
       :param id_ [int] 
       :return FirmClientLinkageOutputModel
     """
+
     def revoke_firm_client_linkage(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/firmclientlinkages/{}/revoke'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/firmclientlinkages/{}/revoke'.format(
+                self.base_url, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4514,12 +6229,20 @@ class Mixin:
       :param model [FreeTrialRequestModel] Required information to provision a free trial account.
       :return NewAccountModel
     """
+
     def request_free_trial(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/freetrials/request'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/freetrials/request'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4546,12 +6269,20 @@ class Mixin:
       :param subscriptionType [POASubscriptionType] The company's subscription type (See POASubscriptionType::* for a list of allowable values)
       :return FundingStatusModel
     """
+
     def activate_funding_request(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/fundingrequests/{}/widget'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/fundingrequests/{}/widget'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4576,12 +6307,20 @@ class Mixin:
       :param subscriptionType [POASubscriptionType] The company's subscription type (See POASubscriptionType::* for a list of allowable values)
       :return FundingStatusModel
     """
+
     def funding_request_status(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/fundingrequests/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/fundingrequests/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4597,12 +6336,22 @@ class Mixin:
       :param itemId [int] The ID of the item you wish to delete the classifications.
       :return ErrorDetail
     """
+
     def batch_delete_item_classifications(self, companyId, itemId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/classifications'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/classifications'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4619,12 +6368,22 @@ class Mixin:
       :param itemId [int] The ID of the item you wish to delete the parameters.
       :return ErrorDetail
     """
+
     def batch_delete_item_parameters(self, companyId, itemId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/parameters'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/parameters'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4644,12 +6403,22 @@ class Mixin:
       :param model [ItemBulkUploadInputModel] The items you wish to upload.
       :return ItemBulkUploadOutputModel
     """
+
     def bulk_upload_items(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items/upload'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items/upload'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4667,12 +6436,22 @@ class Mixin:
       :param model [ItemClassificationInputModel] The item classifications you wish to create.
       :return ItemClassificationOutputModel
     """
+
     def create_item_classifications(self, companyId, itemId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items/{}/classifications'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items/{}/classifications'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4692,12 +6471,22 @@ class Mixin:
       :param model [ItemParameterModel] The item parameters you wish to create.
       :return ItemParameterModel
     """
+
     def create_item_parameters(self, companyId, itemId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items/{}/parameters'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items/{}/parameters'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4717,12 +6506,20 @@ class Mixin:
       :param model [ItemModel] The item you wish to create.
       :return ItemModel
     """
+
     def create_items(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4738,12 +6535,22 @@ class Mixin:
       :param model [ItemTagDetailModel] Tags you wish to associate with the Item
       :return ItemTagDetailModel
     """
+
     def create_item_tags(self, companyId, itemId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items/{}/tags'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items/{}/tags'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4760,12 +6567,22 @@ class Mixin:
       :param model [ItemTaxCodeClassificationRequestInputModel] The request you wish to create.
       :return ItemTaxCodeClassificationRequestOutputModel
     """
+
     def create_tax_code_classification_request(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/classificationrequests/taxcode'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/classificationrequests/taxcode'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4790,12 +6607,22 @@ class Mixin:
       :param itemCode [string] The code of the item you want to delete.
       :return ErrorDetail
     """
+
     def delete_catalogue_item(self, companyId, itemCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/itemcatalogue/{}'.format(self.base_url, companyId, itemCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/itemcatalogue/{}'.format(
+                self.base_url, companyId, itemCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4815,12 +6642,22 @@ class Mixin:
       :param id_ [int] The ID of the item you wish to delete.
       :return ErrorDetail
     """
+
     def delete_item(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4837,12 +6674,22 @@ class Mixin:
       :param id_ [int] The item classification id.
       :return ErrorDetail
     """
+
     def delete_item_classification(self, companyId, itemId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/classifications/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/classifications/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4860,12 +6707,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return ErrorDetail
     """
+
     def delete_item_parameter(self, companyId, itemId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/parameters/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/parameters/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4881,12 +6738,22 @@ class Mixin:
       :param itemTagDetailId [int] The ID of the item tag detail you wish to delete.
       :return ErrorDetail
     """
+
     def delete_item_tag(self, companyId, itemId, itemTagDetailId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/tags/{}'.format(self.base_url, companyId, itemId, itemTagDetailId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/tags/{}'.format(
+                self.base_url, companyId, itemId, itemTagDetailId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4901,12 +6768,22 @@ class Mixin:
       :param itemId [int] The ID of the item as defined by the company that owns this tag.
       :return ErrorDetail
     """
+
     def delete_item_tags(self, companyId, itemId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/items/{}/tags'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/items/{}/tags'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4928,12 +6805,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def get_classification_status(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/classificationrequests/taxcode'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/classificationrequests/taxcode'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4953,12 +6840,22 @@ class Mixin:
       :param include [string] A comma separated list of additional data to retrieve.
       :return ItemModel
     """
+
     def get_item(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4975,12 +6872,22 @@ class Mixin:
       :param id_ [int] The item classification id.
       :return ItemClassificationOutputModel
     """
+
     def get_item_classification(self, companyId, itemId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/classifications/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/classifications/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -4998,12 +6905,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return ItemParameterModel
     """
+
     def get_item_parameter(self, companyId, itemId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/parameters/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/parameters/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5021,12 +6938,22 @@ class Mixin:
       :param skip [int] If nonzero, skip this number of results before returning data. Used with `$top` to provide pagination for large datasets.
       :return FetchResult
     """
+
     def get_item_tags(self, companyId, itemId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/tags'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/tags'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5049,12 +6976,22 @@ class Mixin:
       :param systemCode [string] The SystemCode for which you want to retrieve premium classification
       :return ItemPremiumClassificationOutputModel
     """
+
     def get_premium_classification(self, companyId, itemCode, systemCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/premiumClassification/{}'.format(self.base_url, companyId, itemCode, systemCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/premiumClassification/{}'.format(
+                self.base_url, companyId, itemCode, systemCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5075,12 +7012,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def get_tax_code_recommendations(self, companyId, requestId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/classificationrequests/taxcode/{}/recommendations'.format(self.base_url, companyId, requestId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/classificationrequests/taxcode/{}/recommendations'.format(
+                self.base_url, companyId, requestId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5106,12 +7053,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_import_restrictions(self, companyId, itemCode, countryOfImport, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/restrictions/import/{}'.format(self.base_url, companyId, itemCode, countryOfImport),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_import_restrictions(
+            self, companyId, itemCode, countryOfImport, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/restrictions/import/{}'.format(
+                self.base_url, companyId, itemCode, countryOfImport
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5133,12 +7092,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_item_classifications(self, companyId, itemId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/classifications'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/classifications'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5161,12 +7130,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_item_parameters(self, companyId, itemId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/{}/parameters'.format(self.base_url, companyId, itemId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/{}/parameters'.format(
+                self.base_url, companyId, itemId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5197,12 +7176,20 @@ class Mixin:
       :param tagName [string] Tag Name on the basis of which you want to filter Items
       :return FetchResult
     """
+
     def list_items_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5226,12 +7213,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_items(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/items'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/items'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5257,12 +7252,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_items_by_tag(self, companyId, tag, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/items/bytags/{}'.format(self.base_url, companyId, tag),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/items/bytags/{}'.format(
+                self.base_url, companyId, tag
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5279,12 +7284,22 @@ class Mixin:
       :param model [ItemCatalogueInputModel] The items you want to create or update.
       :return ItemCatalogueOutputModel
     """
+
     def sync_item_catalogue(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/itemcatalogue'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/itemcatalogue'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5306,12 +7321,22 @@ class Mixin:
       :param model [SyncItemsRequestModel] The request object.
       :return SyncItemsResponseModel
     """
+
     def sync_items(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/items/sync'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/items/sync'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5334,12 +7359,22 @@ class Mixin:
       :param model [ItemModel] The item object you wish to update.
       :return ItemModel
     """
+
     def update_item(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/items/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/items/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5358,12 +7393,22 @@ class Mixin:
       :param model [ItemClassificationInputModel] The item object you wish to update.
       :return ItemClassificationOutputModel
     """
+
     def update_item_classification(self, companyId, itemId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/items/{}/classifications/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/items/{}/classifications/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5382,12 +7427,22 @@ class Mixin:
       :param model [ItemParameterModel] The item object you wish to update.
       :return ItemParameterModel
     """
+
     def update_item_parameter(self, companyId, itemId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/items/{}/parameters/{}'.format(self.base_url, companyId, itemId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/items/{}/parameters/{}'.format(
+                self.base_url, companyId, itemId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5405,12 +7460,22 @@ class Mixin:
       :param model [JurisdictionOverrideModel] The jurisdiction override objects to create
       :return JurisdictionOverrideModel
     """
+
     def create_jurisdiction_overrides(self, accountId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/jurisdictionoverrides'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/jurisdictionoverrides'.format(
+                self.base_url, accountId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5424,12 +7489,22 @@ class Mixin:
       :param id_ [int] The ID of the override you wish to delete
       :return ErrorDetail
     """
+
     def delete_jurisdiction_override(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5447,12 +7522,22 @@ class Mixin:
       :param id_ [int] The primary key of this override
       :return JurisdictionOverrideModel
     """
+
     def get_jurisdiction_override(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5476,12 +7561,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_jurisdiction_overrides_by_account(self, accountId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/jurisdictionoverrides'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/jurisdictionoverrides'.format(
+                self.base_url, accountId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5504,12 +7599,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_jurisdiction_overrides(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/jurisdictionoverrides'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/jurisdictionoverrides'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5524,12 +7627,22 @@ class Mixin:
       :param model [JurisdictionOverrideModel] The jurisdictionoverride object you wish to update.
       :return JurisdictionOverrideModel
     """
+
     def update_jurisdiction_override(self, accountId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/accounts/{}/jurisdictionoverrides/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5549,12 +7662,22 @@ class Mixin:
       :param model [LocationParameterModel] The location parameters you wish to create.
       :return LocationParameterModel
     """
+
     def create_location_parameters(self, companyId, locationId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/locations/{}/parameters'.format(self.base_url, companyId, locationId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/locations/{}/parameters'.format(
+                self.base_url, companyId, locationId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5568,12 +7691,22 @@ class Mixin:
       :param model [LocationModel] The location you wish to create.
       :return LocationModel
     """
+
     def create_locations(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/locations'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/locations'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5587,12 +7720,22 @@ class Mixin:
       :param id_ [int] The ID of the location you wish to delete.
       :return ErrorDetail
     """
+
     def delete_location(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/locations/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/locations/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5610,12 +7753,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return ErrorDetail
     """
+
     def delete_location_parameter(self, companyId, locationId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(self.base_url, companyId, locationId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(
+                self.base_url, companyId, locationId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5637,12 +7790,22 @@ class Mixin:
       :param include [string] A comma separated list of additional data to retrieve.
       :return LocationModel
     """
+
     def get_location(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5660,12 +7823,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return LocationParameterModel
     """
+
     def get_location_parameter(self, companyId, locationId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(self.base_url, companyId, locationId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(
+                self.base_url, companyId, locationId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5688,12 +7861,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_location_parameters(self, companyId, locationId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations/{}/parameters'.format(self.base_url, companyId, locationId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations/{}/parameters'.format(
+                self.base_url, companyId, locationId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5720,12 +7903,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_locations_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5751,12 +7944,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_locations(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/locations'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/locations'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5773,12 +7974,22 @@ class Mixin:
       :param model [LocationModel] The location you wish to update.
       :return LocationModel
     """
+
     def update_location(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/locations/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/locations/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5797,12 +8008,22 @@ class Mixin:
       :param model [LocationParameterModel] The location parameter object you wish to update.
       :return LocationParameterModel
     """
+
     def update_location_parameter(self, companyId, locationId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(self.base_url, companyId, locationId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/locations/{}/parameters/{}'.format(
+                self.base_url, companyId, locationId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5818,12 +8039,22 @@ class Mixin:
       :param id_ [int] The primary key of this location
       :return LocationValidationModel
     """
+
     def validate_location(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations/{}/validate'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations/{}/validate'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5852,12 +8083,25 @@ class Mixin:
       :param model [AdjustMultiDocumentModel] The adjust request you wish to execute
       :return MultiDocumentModel
     """
-    def adjust_multi_document_transaction(self, code, type, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument/{}/type/{}/adjust'.format(self.base_url, code, type),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def adjust_multi_document_transaction(
+            self, code, type, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument/{}/type/{}/adjust'.format(
+                self.base_url, code, type
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5889,12 +8133,22 @@ class Mixin:
       :param type [DocumentType] The transaction type for this MultiDocument transaction (See DocumentType::* for a list of allowable values)
       :return AuditMultiDocumentModel
     """
+
     def audit_multi_document_transaction(self, code, type):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/transactions/multidocument/{}/type/{}/audit'.format(self.base_url, code, type),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/transactions/multidocument/{}/type/{}/audit'.format(
+                self.base_url, code, type
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5919,12 +8173,22 @@ class Mixin:
       :param model [CommitMultiDocumentModel] The commit request you wish to execute
       :return MultiDocumentModel
     """
+
     def commit_multi_document_transaction(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument/commit'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument/commit'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -5969,12 +8233,21 @@ class Mixin:
       :param model [CreateMultiDocumentModel] the multi document transaction model
       :return MultiDocumentModel
     """
+
     def create_multi_document_transaction(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6005,12 +8278,24 @@ class Mixin:
       :param include [string] Specifies objects to include in the response after transaction is created
       :return MultiDocumentModel
     """
-    def get_multi_document_transaction_by_code_and_type(self, code, type, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/transactions/multidocument/{}/type/{}'.format(self.base_url, code, type),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def get_multi_document_transaction_by_code_and_type(
+            self, code, type, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/transactions/multidocument/{}/type/{}'.format(
+                self.base_url, code, type
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6047,12 +8332,22 @@ class Mixin:
       :param include [string] Specifies objects to include in the response after transaction is created
       :return MultiDocumentModel
     """
+
     def get_multi_document_transaction_by_id(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/transactions/multidocument/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/transactions/multidocument/{}'.format(
+                self.base_url, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6090,12 +8385,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_multi_document_transactions(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/transactions/multidocument'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/transactions/multidocument'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6145,12 +8448,25 @@ class Mixin:
       :param model [RefundTransactionModel] Information about the refund to create
       :return MultiDocumentModel
     """
-    def refund_multi_document_transaction(self, code, type, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument/{}/type/{}/refund'.format(self.base_url, code, type),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def refund_multi_document_transaction(
+            self, code, type, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument/{}/type/{}/refund'.format(
+                self.base_url, code, type
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6174,12 +8490,22 @@ class Mixin:
       :param model [VerifyMultiDocumentModel] Information from your accounting system to verify against this MultiDocument transaction as it is stored in AvaTax
       :return MultiDocumentModel
     """
+
     def verify_multi_document_transaction(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument/verify'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument/verify'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6207,12 +8533,22 @@ class Mixin:
       :param model [VoidTransactionModel] The void request you wish to execute
       :return MultiDocumentModel
     """
+
     def void_multi_document_transaction(self, code, type, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/multidocument/{}/type/{}/void'.format(self.base_url, code, type),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/multidocument/{}/type/{}/void'.format(
+                self.base_url, code, type
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6239,12 +8575,20 @@ class Mixin:
       :param model [NexusModel] The nexus you wish to create.
       :return NexusModel
     """
+
     def create_nexus(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/nexus'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/nexus'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6264,12 +8608,22 @@ class Mixin:
       :param model [NexusParameterDetailModel] The nexus parameters you wish to create.
       :return NexusParameterDetailModel
     """
+
     def create_nexus_parameters(self, companyId, nexusId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/nexus/{}/parameters'.format(self.base_url, companyId, nexusId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/nexus/{}/parameters'.format(
+                self.base_url, companyId, nexusId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6293,12 +8647,22 @@ class Mixin:
       :param model [DeclareNexusByAddressModel] The nexus you wish to create.
       :return NexusByAddressModel
     """
+
     def declare_nexus_by_address(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/nexus/byaddress'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/nexus/byaddress'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6318,12 +8682,22 @@ class Mixin:
       :param cascadeDelete [boolean] If true, deletes all the child nexus if they exist along with parent nexus
       :return ErrorDetail
     """
+
     def delete_nexus(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/nexus/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/nexus/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6341,12 +8715,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return ErrorDetail
     """
+
     def delete_nexus_parameter(self, companyId, nexusId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(self.base_url, companyId, nexusId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(
+                self.base_url, companyId, nexusId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6363,12 +8747,22 @@ class Mixin:
       :param nexusId [int] The ID of the nexus you wish to delete the parameters.
       :return ErrorDetail
     """
+
     def delete_nexus_parameters(self, companyId, nexusId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/nexus/{}/parameters'.format(self.base_url, companyId, nexusId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/nexus/{}/parameters'.format(
+                self.base_url, companyId, nexusId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6388,12 +8782,22 @@ class Mixin:
       :param include [string] 
       :return NexusModel
     """
+
     def get_nexus(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6416,12 +8820,22 @@ class Mixin:
       :param include [string] 
       :return NexusByTaxFormModel
     """
+
     def get_nexus_by_form_code(self, companyId, formCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus/byform/{}'.format(self.base_url, companyId, formCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus/byform/{}'.format(
+                self.base_url, companyId, formCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6439,12 +8853,22 @@ class Mixin:
       :param id_ [int] The parameter id
       :return NexusParameterDetailModel
     """
+
     def get_nexus_parameter(self, companyId, nexusId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(self.base_url, companyId, nexusId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(
+                self.base_url, companyId, nexusId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6469,12 +8893,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6500,12 +8932,24 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
-    def list_nexus_by_company_and_tax_type_group(self, companyId, taxTypeGroup, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus/byTaxTypeGroup/{}'.format(self.base_url, companyId, taxTypeGroup),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def list_nexus_by_company_and_tax_type_group(
+            self, companyId, taxTypeGroup, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus/byTaxTypeGroup/{}'.format(
+                self.base_url, companyId, taxTypeGroup
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6528,12 +8972,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_nexus_parameters(self, companyId, nexusId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/nexus/{}/parameters'.format(self.base_url, companyId, nexusId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/nexus/{}/parameters'.format(
+                self.base_url, companyId, nexusId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6557,12 +9011,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_nexus(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/nexus'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/nexus'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6590,12 +9052,22 @@ class Mixin:
       :param model [NexusModel] The nexus object you wish to update.
       :return NexusModel
     """
+
     def update_nexus(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/nexus/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/nexus/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6614,12 +9086,22 @@ class Mixin:
       :param model [NexusParameterDetailModel] The nexus object you wish to update.
       :return NexusParameterDetailModel
     """
+
     def update_nexus_parameter(self, companyId, nexusId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(self.base_url, companyId, nexusId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/nexus/{}/parameters/{}'.format(
+                self.base_url, companyId, nexusId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6633,12 +9115,20 @@ class Mixin:
       :param model [CreateNoticeResponsibilityTypeModel] The responsibility type to create
       :return NoticeResponsibilityModel
     """
+
     def create_notice_responsibility_type(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/notices/responsibilities'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/notices/responsibilities'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6652,12 +9142,20 @@ class Mixin:
       :param model [CreateNoticeRootCauseTypeModel] The root cause type to create
       :return NoticeRootCauseModel
     """
+
     def create_notice_root_cause_type(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/notices/rootcauses'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/notices/rootcauses'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6670,12 +9168,22 @@ class Mixin:
       :param responsibilityId [int] The unique ID of the responsibility type
       :return ErrorDetail
     """
+
     def delete_notice_responsibility_type(self, responsibilityId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/notices/responsibilities/{}'.format(self.base_url, responsibilityId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/notices/responsibilities/{}'.format(
+                self.base_url, responsibilityId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6688,12 +9196,22 @@ class Mixin:
       :param rootCauseId [int] The unique ID of the root cause type
       :return ErrorDetail
     """
+
     def delete_notice_root_cause_type(self, rootCauseId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/notices/rootcauses/{}'.format(self.base_url, rootCauseId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/notices/rootcauses/{}'.format(
+                self.base_url, rootCauseId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6715,12 +9233,20 @@ class Mixin:
       :param id_ [int] The id of the notification you wish to mark as dismissed.
       :return NotificationModel
     """
+
     def dismiss_notification(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/notifications/{}/dismiss'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/notifications/{}/dismiss'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6738,12 +9264,20 @@ class Mixin:
       :param id_ [int] The id of the notification to retrieve.
       :return NotificationModel
     """
+
     def get_notification(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/notifications/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/notifications/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6766,12 +9300,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_notifications(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/notifications'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/notifications'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6796,12 +9338,20 @@ class Mixin:
       :param model [NewAccountRequestModel] Information about the account you wish to create and the selected product offerings.
       :return NewAccountModel
     """
+
     def request_new_account(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/request'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/request'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6818,12 +9368,22 @@ class Mixin:
       :param offer [string] The offer to be added to an already existing customer
       :return OfferModel
     """
+
     def request_new_entitlement(self, id_, offer):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/entitlements/{}'.format(self.base_url, id_, offer),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/entitlements/{}'.format(
+                self.base_url, id_, offer
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6839,12 +9399,20 @@ class Mixin:
       :param model [AccountModel] The account you wish to create.
       :return AccountModel
     """
+
     def create_account(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6866,12 +9434,20 @@ class Mixin:
       :param model [NotificationModel] The notifications you wish to create.
       :return NotificationModel
     """
+
     def create_notifications(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/notifications'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/notifications'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6888,12 +9464,22 @@ class Mixin:
       :param model [SubscriptionModel] The subscription you wish to create.
       :return SubscriptionModel
     """
+
     def create_subscriptions(self, accountId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/subscriptions'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/subscriptions'.format(
+                self.base_url, accountId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6909,12 +9495,20 @@ class Mixin:
       :param id_ [int] The ID of the account you wish to delete.
       :return ErrorDetail
     """
+
     def delete_account(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/accounts/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/accounts/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6934,12 +9528,20 @@ class Mixin:
       :param id_ [int] The id of the notification you wish to delete.
       :return ErrorDetail
     """
+
     def delete_notification(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/notifications/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/notifications/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6955,12 +9557,22 @@ class Mixin:
       :param id_ [int] The ID of the subscription you wish to delete.
       :return ErrorDetail
     """
+
     def delete_subscription(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/accounts/{}/subscriptions/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/accounts/{}/subscriptions/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -6980,12 +9592,21 @@ class Mixin:
       :param model [SetPasswordModel] The new password for this user
       :return string
     """
+
     def reset_password(self, userId, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/passwords/{}/reset'.format(self.base_url, userId),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/passwords/{}/reset'.format(self.base_url, userId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7001,12 +9622,20 @@ class Mixin:
       :param model [AccountModel] The account object you wish to update.
       :return AccountModel
     """
+
     def update_account(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/accounts/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/accounts/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7027,12 +9656,20 @@ class Mixin:
       :param model [NotificationModel] The notification object you wish to update.
       :return NotificationModel
     """
+
     def update_notification(self, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/notifications/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/notifications/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7053,12 +9690,22 @@ class Mixin:
       :param model [SubscriptionModel] The subscription you wish to update.
       :return SubscriptionModel
     """
+
     def update_subscription(self, accountId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/accounts/{}/subscriptions/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/accounts/{}/subscriptions/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7080,12 +9727,20 @@ class Mixin:
       :param id_ [int] The unique ID number of this report
       :return String
     """
+
     def download_report(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/reports/{}/attachment'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/reports/{}/attachment'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7103,12 +9758,20 @@ class Mixin:
       :param id_ [int] The unique ID number of the report to retrieve
       :return ReportModel
     """
+
     def get_report(self, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/reports/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/reports/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7135,12 +9798,22 @@ class Mixin:
       :param model [ExportDocumentLineModel] Options that may be configured to customize the report.
       :return ReportModel
     """
+
     def initiate_export_document_line_report(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/reports/exportdocumentline/initiate'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/reports/exportdocumentline/initiate'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7163,12 +9836,20 @@ class Mixin:
       :param top [int] If nonzero, return no more than this number of results. Used with `$skip` to provide pagination for large datasets. Unless otherwise specified, the maximum number of records that can be returned from an API call is 1,000 records.
       :return FetchResult
     """
+
     def list_reports(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/reports'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/reports'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7192,12 +9873,20 @@ class Mixin:
       :param model [SettingModel] The setting you wish to create.
       :return SettingModel
     """
+
     def create_settings(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/settings'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/settings'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7218,12 +9907,22 @@ class Mixin:
       :param id_ [int] The ID of the setting you wish to delete.
       :return ErrorDetail
     """
+
     def delete_setting(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/settings/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/settings/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7244,12 +9943,22 @@ class Mixin:
       :param id_ [int] The primary key of this setting
       :return SettingModel
     """
+
     def get_setting(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/settings/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/settings/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7276,12 +9985,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_settings_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/settings'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/settings'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7307,12 +10024,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_settings(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/settings'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/settings'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7336,12 +10061,22 @@ class Mixin:
       :param model [SettingModel] The setting you wish to update.
       :return SettingModel
     """
+
     def update_setting(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/settings/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/settings/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7357,12 +10092,22 @@ class Mixin:
       :param id_ [int] The primary key of this subscription
       :return SubscriptionModel
     """
+
     def get_subscription(self, accountId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/subscriptions/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/subscriptions/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7383,12 +10128,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_subscriptions_by_account(self, accountId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/subscriptions'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/subscriptions'.format(
+                self.base_url, accountId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7408,12 +10163,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_subscriptions(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/subscriptions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/subscriptions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7431,12 +10194,20 @@ class Mixin:
       :param model [TaxCodeModel] The tax code you wish to create.
       :return TaxCodeModel
     """
+
     def create_tax_codes(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/taxcodes'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/taxcodes'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7450,12 +10221,22 @@ class Mixin:
       :param id_ [int] The ID of the tax code you wish to delete.
       :return ErrorDetail
     """
+
     def delete_tax_code(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/taxcodes/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/taxcodes/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7473,12 +10254,22 @@ class Mixin:
       :param id_ [int] The primary key of this tax code
       :return TaxCodeModel
     """
+
     def get_tax_code(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/taxcodes/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/taxcodes/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7502,12 +10293,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_codes_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/taxcodes'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/taxcodes'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7530,12 +10329,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_tax_codes(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/taxcodes'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/taxcodes'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7556,12 +10363,22 @@ class Mixin:
       :param model [TaxCodeModel] The tax code you wish to update.
       :return TaxCodeModel
     """
+
     def update_tax_code(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/taxcodes/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/taxcodes/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7591,12 +10408,20 @@ class Mixin:
       :param model [PointOfSaleDataRequestModel] Parameters about the desired file format and report format, specifying which company, locations and TaxCodes to include.
       :return String
     """
+
     def build_tax_content_file(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/pointofsaledata/build'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/pointofsaledata/build'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7631,12 +10456,24 @@ class Mixin:
       :param includeJurisCodes [boolean] When true, the file will include jurisdiction codes in the result.
       :return String
     """
-    def build_tax_content_file_for_location(self, companyId, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/locations/{}/pointofsaledata'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def build_tax_content_file_for_location(
+            self, companyId, id_, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/locations/{}/pointofsaledata'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7682,12 +10519,22 @@ class Mixin:
       :param region [string] A two character region code which limits results to a specific region.
       :return String
     """
+
     def download_tax_rates_by_zip_code(self, date, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/taxratesbyzipcode/download/{}'.format(self.base_url, date),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/taxratesbyzipcode/download/{}'.format(
+                self.base_url, date
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7719,12 +10566,20 @@ class Mixin:
       :param country [string] Name or ISO 3166 code identifying the country.     This field supports many different country identifiers:   * Two character ISO 3166 codes   * Three character ISO 3166 codes   * Fully spelled out names of the country in ISO supported languages   * Common alternative spellings for many countries     For a full list of all supported codes and names, please see the Definitions API `ListCountries`.
       :return TaxRateModel
     """
+
     def tax_rates_by_address(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/taxrates/byaddress'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/taxrates/byaddress'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7752,12 +10607,20 @@ class Mixin:
       :param postalCode [string] The postal code of the location.
       :return TaxRateModel
     """
+
     def tax_rates_by_postal_code(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/taxrates/bypostalcode'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/taxrates/bypostalcode'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7780,12 +10643,20 @@ class Mixin:
       :param model [TaxRuleModel] The tax rule you wish to create.
       :return TaxRuleModel
     """
+
     def create_tax_rules(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/taxrules'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/taxrules'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7808,12 +10679,22 @@ class Mixin:
       :param id_ [int] The ID of the tax rule you wish to delete.
       :return ErrorDetail
     """
+
     def delete_tax_rule(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/taxrules/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/taxrules/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7836,12 +10717,22 @@ class Mixin:
       :param id_ [int] The primary key of this tax rule
       :return TaxRuleModel
     """
+
     def get_tax_rule(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/taxrules/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/taxrules/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7870,12 +10761,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_tax_rules(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/taxrules'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/taxrules'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7903,12 +10802,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_tax_rules(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/taxrules'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/taxrules'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7932,12 +10839,22 @@ class Mixin:
       :param model [TaxRuleModel] The tax rule you wish to update.
       :return TaxRuleModel
     """
+
     def update_tax_rule(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/taxrules/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/taxrules/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -7967,12 +10884,21 @@ class Mixin:
       :param model [AddTransactionLineModel] information about the transaction and lines to be added
       :return TransactionModel
     """
+
     def add_lines(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/transactions/lines/add'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/transactions/lines/add'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8012,12 +10938,25 @@ class Mixin:
       :param model [AdjustTransactionModel] The adjustment you wish to make
       :return TransactionModel
     """
-    def adjust_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/adjust'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def adjust_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/adjust'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8049,12 +10988,22 @@ class Mixin:
       :param transactionCode [string] The code identifying the transaction
       :return AuditTransactionModel
     """
+
     def audit_transaction(self, companyCode, transactionCode):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/transactions/{}/audit'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions/{}/audit'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8087,12 +11036,24 @@ class Mixin:
       :param documentType [DocumentType] The document type of the original transaction (See DocumentType::* for a list of allowable values)
       :return AuditTransactionModel
     """
-    def audit_transaction_with_type(self, companyCode, transactionCode, documentType):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/transactions/{}/types/{}/audit'.format(self.base_url, companyCode, transactionCode, documentType),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def audit_transaction_with_type(
+            self, companyCode, transactionCode, documentType
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions/{}/types/{}/audit'.format(
+                self.base_url, companyCode, transactionCode, documentType
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8110,12 +11071,20 @@ class Mixin:
       :param model [BulkLockTransactionModel] bulk lock request
       :return BulkLockTransactionResult
     """
+
     def bulk_lock_transaction(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/lock'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/lock'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8154,12 +11123,25 @@ class Mixin:
       :param model [ChangeTransactionCodeModel] The code change request you wish to execute
       :return TransactionModel
     """
-    def change_transaction_code(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/changecode'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def change_transaction_code(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/changecode'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8196,12 +11178,25 @@ class Mixin:
       :param model [CommitTransactionModel] The commit request you wish to execute
       :return TransactionModel
     """
-    def commit_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/commit'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def commit_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/commit'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8240,12 +11235,21 @@ class Mixin:
       :param model [CreateOrAdjustTransactionModel] The transaction you wish to create or adjust
       :return TransactionModel
     """
+
     def create_or_adjust_transaction(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/createoradjust'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/createoradjust'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8289,12 +11293,21 @@ class Mixin:
       :param model [CreateTransactionModel] The transaction you wish to create
       :return TransactionModel
     """
+
     def create_transaction(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/transactions/create'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/transactions/create'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8321,12 +11334,23 @@ class Mixin:
       :param model [RemoveTransactionLineModel] information about the transaction and lines to be removed
       :return TransactionModel
     """
+
     def delete_lines(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/transactions/lines/delete'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/transactions/lines/delete'.format(
+                self.base_url
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8362,12 +11386,24 @@ class Mixin:
       :param include [string] Specifies objects to include in this fetch call
       :return TransactionModel
     """
-    def get_transaction_by_code(self, companyCode, transactionCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/transactions/{}'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def get_transaction_by_code(
+            self, companyCode, transactionCode, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions/{}'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8391,12 +11427,24 @@ class Mixin:
       :param include [string] Specifies objects to include in this fetch call
       :return TransactionModel
     """
-    def get_transaction_by_code_and_type(self, companyCode, transactionCode, documentType, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/transactions/{}/types/{}'.format(self.base_url, companyCode, transactionCode, documentType),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def get_transaction_by_code_and_type(
+            self, companyCode, transactionCode, documentType, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions/{}/types/{}'.format(
+                self.base_url, companyCode, transactionCode, documentType
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8422,12 +11470,20 @@ class Mixin:
       :param include [string] Specifies objects to include in this fetch call
       :return TransactionModel
     """
+
     def get_transaction_by_id(self, id_, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/transactions/{}'.format(self.base_url, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/transactions/{}'.format(self.base_url, id_),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8468,12 +11524,22 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_transactions_by_company(self, companyCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/transactions'.format(self.base_url, companyCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions'.format(
+                self.base_url, companyCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8512,12 +11578,25 @@ class Mixin:
       :param model [LockTransactionModel] The lock request you wish to execute
       :return TransactionModel
     """
-    def lock_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/lock'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def lock_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/lock'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8566,12 +11645,25 @@ class Mixin:
       :param model [RefundTransactionModel] Information about the refund to create
       :return TransactionModel
     """
-    def refund_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/refund'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def refund_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/refund'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8608,12 +11700,25 @@ class Mixin:
       :param model [SettleTransactionModel] The data from an external system to reconcile against AvaTax
       :return TransactionModel
     """
-    def settle_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/settle'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def settle_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/settle'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8647,12 +11752,22 @@ class Mixin:
       :param include [string] Specifies objects to include in this fetch call
       :return TransactionModel
     """
+
     def uncommit_transaction(self, companyCode, transactionCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/uncommit'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/uncommit'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8684,12 +11799,22 @@ class Mixin:
       :param include [string] Specifies objects to include in this fetch call
       :return TransactionModel
     """
+
     def unvoid_transaction(self, companyCode, transactionCode, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/unvoid'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/unvoid'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8726,12 +11851,25 @@ class Mixin:
       :param model [VerifyTransactionModel] The data from an external system to reconcile against AvaTax
       :return TransactionModel
     """
-    def verify_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/verify'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def verify_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/verify'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8769,12 +11907,25 @@ class Mixin:
       :param model [VoidTransactionModel] The void request you wish to execute. To void a transaction the code must be set to 'DocVoided'
       :return TransactionModel
     """
-    def void_transaction(self, companyCode, transactionCode, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/transactions/{}/void'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+
+    def void_transaction(
+            self, companyCode, transactionCode, model, include=None
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/transactions/{}/void'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8790,12 +11941,20 @@ class Mixin:
       :param model [UPCModel] The UPC you wish to create.
       :return UPCModel
     """
+
     def create_u_p_cs(self, companyId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/upcs'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/upcs'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8810,12 +11969,22 @@ class Mixin:
       :param id_ [int] The ID of the UPC you wish to delete.
       :return ErrorDetail
     """
+
     def delete_u_p_c(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/upcs/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/upcs/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8831,12 +12000,22 @@ class Mixin:
       :param id_ [int] The primary key of this UPC
       :return UPCModel
     """
+
     def get_u_p_c(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/upcs/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/upcs/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8858,12 +12037,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_u_p_cs_by_company(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/upcs'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/upcs'.format(self.base_url, companyId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8884,12 +12071,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_u_p_cs(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/upcs'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/upcs'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8908,12 +12103,22 @@ class Mixin:
       :param model [UPCModel] The UPC you wish to update.
       :return UPCModel
     """
+
     def update_u_p_c(self, companyId, id_, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/companies/{}/upcs/{}'.format(self.base_url, companyId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/companies/{}/upcs/{}'.format(
+                self.base_url, companyId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8928,12 +12133,22 @@ class Mixin:
       :param id_ [int] The id of the User Defined Field you wish to delete.
       :return ErrorDetail
     """
+
     def delete_user_defined_field(self, companyId, id_):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/companies/{}/userdefinedfields/{}'.format(self.base_url, companyId, accountId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/companies/{}/userdefinedfields/{}'.format(
+                self.base_url, companyId, accountId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8948,12 +12163,22 @@ class Mixin:
       :param allowDefaults [boolean] If true this will add defaulted UDFs to the list that are not named yet
       :return FetchResult
     """
+
     def list_user_defined_fields_by_company_id(self, companyId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/companies/{}/userdefinedfields'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/companies/{}/userdefinedfields'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8969,12 +12194,23 @@ class Mixin:
       :param model [CompanyUserDefinedFieldModel] 
       :return CompanyUserDefinedFieldModel
     """
+
     def update_user_defined_field(self, companyId, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/companies/{}/userdefinedfields'.format(self.base_url, companyId),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/companies/{}/userdefinedfields'.format(
+                self.base_url, companyId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -8991,12 +12227,20 @@ class Mixin:
       :param model [PasswordChangeModel] An object containing your current password and the new password.
       :return string
     """
+
     def change_password(self, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/passwords'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/passwords'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9015,12 +12259,20 @@ class Mixin:
       :param model [UserModel] The user or array of users you wish to create.
       :return UserModel
     """
+
     def create_users(self, accountId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.post('{}/api/v2/accounts/{}/users'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.post(
+            '{}/api/v2/accounts/{}/users'.format(self.base_url, accountId),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9037,12 +12289,22 @@ class Mixin:
       :param accountId [int] The accountID of the user you wish to delete.
       :return ErrorDetail
     """
+
     def delete_user(self, id_, accountId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.delete('{}/api/v2/accounts/{}/users/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.delete(
+            '{}/api/v2/accounts/{}/users/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9060,12 +12322,22 @@ class Mixin:
       :param include [string] Optional fetch commands.
       :return UserModel
     """
+
     def get_user(self, id_, accountId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/users/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/users/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9091,12 +12363,22 @@ class Mixin:
       :param accountId [int] The accountID of the user you wish to get.
       :return UserEntitlementModel
     """
+
     def get_user_entitlements(self, id_, accountId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/users/{}/entitlements'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/users/{}/entitlements'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9121,12 +12403,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def list_users_by_account(self, accountId, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/accounts/{}/users'.format(self.base_url, accountId),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/accounts/{}/users'.format(self.base_url, accountId),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9151,12 +12441,20 @@ class Mixin:
       :param orderBy [string] A comma separated list of sort statements in the format `(fieldname) [ASC|DESC]`, for example `id ASC`.
       :return FetchResult
     """
+
     def query_users(self, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/users'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/users'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9174,12 +12472,22 @@ class Mixin:
       :param model [UserModel] The user object you wish to update.
       :return UserModel
     """
+
     def update_user(self, id_, accountId, model):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.put('{}/api/v2/accounts/{}/users/{}'.format(self.base_url, accountId, id_),
-                               auth=self.auth, headers=self.client_header, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.put(
+            '{}/api/v2/accounts/{}/users/{}'.format(
+                self.base_url, accountId, id_
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9195,12 +12503,22 @@ class Mixin:
       :param serviceTypeId [string] The service to check
       :return SubscriptionModel
     """
+
     def get_my_subscription(self, serviceTypeId):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/utilities/subscriptions/{}'.format(self.base_url, serviceTypeId),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/utilities/subscriptions/{}'.format(
+                self.base_url, serviceTypeId
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9215,12 +12533,20 @@ class Mixin:
     
       :return FetchResult
     """
+
     def list_my_subscriptions(self):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/utilities/subscriptions'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/utilities/subscriptions'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxClient
     
@@ -9244,12 +12570,20 @@ class Mixin:
     
       :return PingResultModel
     """
+
     def ping(self):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","22.9.0")   
-        return requests.get('{}/api/v2/utilities/ping'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=None, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", "22.9.0"
+            )
+        return requests.get(
+            '{}/api/v2/utilities/ping'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=None,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxBeverageClient
     
@@ -9271,12 +12605,21 @@ class Mixin:
       :param model [AgeVerifyRequest] Information about the individual whose age is being verified.
       :return AgeVerifyResult
     """
+
     def verify_age(self, model, include=None):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","")   
-        return requests.post('{}/api/v2/ageverification/verify'.format(self.base_url),
-                               auth=self.auth, headers=self.client_header, params=include, json=model, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", ""
+            )
+        return requests.post(
+            '{}/api/v2/ageverification/verify'.format(self.base_url),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            json=model,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxBeverageClient
     
@@ -9291,14 +12634,26 @@ class Mixin:
       :param x-avalara-version [string] (Optional): API version that should satisfy the request. If omitted, defaults to 2.2. Header takes precendence if both header and query parameters are present.
       :return 
     """
-    def deregister_shipment(self, companyCode, transactionCode, include=None, x_avalara_version =""):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","")   
+
+    def deregister_shipment(
+            self, companyCode, transactionCode, include=None, x_avalara_version=""
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", ""
+            )
         if x_avalara_version:
-            self.client_header['x-avalara-version']=x_avalara_version;
-        return requests.delete('{}/api/v2/companies/{}/transactions/{}/shipment/registration'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+            self.client_header['x-avalara-version'] = x_avalara_version
+        return requests.delete(
+            '{}/api/v2/companies/{}/transactions/{}/shipment/registration'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxBeverageClient
     
@@ -9313,14 +12668,26 @@ class Mixin:
       :param x-avalara-version [string] (Optional): API version that should satisfy the request. If omitted, defaults to 2.2. Header takes precendence if both header and query parameters are present.
       :return 
     """
-    def register_shipment(self, companyCode, transactionCode, include=None, x_avalara_version =""):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","")   
+
+    def register_shipment(
+            self, companyCode, transactionCode, include=None, x_avalara_version=""
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", ""
+            )
         if x_avalara_version:
-            self.client_header['x-avalara-version']=x_avalara_version;
-        return requests.put('{}/api/v2/companies/{}/transactions/{}/shipment/registration'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+            self.client_header['x-avalara-version'] = x_avalara_version
+        return requests.put(
+            '{}/api/v2/companies/{}/transactions/{}/shipment/registration'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxBeverageClient
     
@@ -9335,14 +12702,26 @@ class Mixin:
       :param x-avalara-version [string] (Optional): API version that should satisfy the request. If omitted, defaults to 2.2. Header takes precendence if both header and query parameters are present.
       :return ShippingVerifyResult
     """
-    def register_shipment_if_compliant(self, companyCode, transactionCode, include=None, x_avalara_version =""):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","")   
+
+    def register_shipment_if_compliant(
+            self, companyCode, transactionCode, include=None, x_avalara_version=""
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", ""
+            )
         if x_avalara_version:
-            self.client_header['x-avalara-version']=x_avalara_version;
-        return requests.put('{}/api/v2/companies/{}/transactions/{}/shipment/registerIfCompliant'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200)
+            self.client_header['x-avalara-version'] = x_avalara_version
+        return requests.put(
+            '{}/api/v2/companies/{}/transactions/{}/shipment/registerIfCompliant'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )
+
     r"""
     Swagger Name: AvaTaxBeverageClient
     
@@ -9370,11 +12749,22 @@ class Mixin:
       :param x-avalara-version [string] (Optional): API version that should satisfy the request. If omitted, defaults to 2.2. Header takes precendence if both header and query parameters are present.
       :return ShippingVerifyResult
     """
-    def verify_shipment(self, companyCode, transactionCode, include=None, x_avalara_version =""):
-        if ('X-Avalara-Client' in self.client_header): 
-            self.client_header['X-Avalara-Client']=self.client_id.replace("API_VERSION","")   
+
+    def verify_shipment(
+            self, companyCode, transactionCode, include=None, x_avalara_version=""
+    ):
+        if 'X-Avalara-Client' in self.client_header:
+            self.client_header['X-Avalara-Client'] = self.client_id.replace(
+                "API_VERSION", ""
+            )
         if x_avalara_version:
-            self.client_header['x-avalara-version']=x_avalara_version;
-        return requests.get('{}/api/v2/companies/{}/transactions/{}/shipment/verify'.format(self.base_url, companyCode, transactionCode),
-                               auth=self.auth, headers=self.client_header, params=include, 
-                               timeout=self.timeout_limit if self.timeout_limit else 1200) 
+            self.client_header['x-avalara-version'] = x_avalara_version
+        return requests.get(
+            '{}/api/v2/companies/{}/transactions/{}/shipment/verify'.format(
+                self.base_url, companyCode, transactionCode
+            ),
+            auth=self.auth,
+            headers=self.client_header,
+            params=include,
+            timeout=self.timeout_limit if self.timeout_limit else 1200,
+        )


### PR DESCRIPTION
This PR contains code to add logging to Python V2 SDK.
Logging is implemented using standard Python logging framework.

1. All relevant methods from `AvataxClient` class are decorated with `ava_log` decorator.(This is achieved using another decorator at class level, `decorate_all_methods`)
2. `ava_log` decorator collects relevant request data, response data useful for instrumentation and logs error data in case of exception.
3. `AvataxClient` constructor is modified with optional parameter, `is_log_req_resp_allowed` (defaulted to False), to control if log entry should contain request and response objects.
4. By default basic logging configuration is used, however configuration can be overriden. SDK Consumer code can also set logger property of `AvataxClient` to use already configured logger instance. e.g. 
```
from logging import config 

# configure logging using file config or dictConfig 
# or by setting basicConfig (this is default in case no logger is set)
config.fileConfig("logger_config.conf")

logger = logging.getLogger()

# set logger property
client.logger = logger
```
    