### PR TITLE
Conditionally add execution_time to error output to avoid KeyError

### DIFF
--- a/src/avalara/ava_logger.py
+++ b/src/avalara/ava_logger.py
@@ -46,7 +46,7 @@ def ava_log(func):
             raise e
         finally:
             total_execution_time = time.perf_counter() - execution_start_time
-            if ava_log_entry["execution_time"] is None:
+            if "execution_time" not in ava_log_entry:
                 ava_log_entry["execution_time"] = total_execution_time * 1000
             json_data = json.dumps(ava_log_entry, indent=4)
             if is_error_log:


### PR DESCRIPTION
This change avoids a KeyError if the wrapped func at L39 throws an exception caught at L43.  In this case `get_ava_log_entry` does not execute and the `ava_log_entry` only contains a value for the caught "error" key.  

Proposal to fix issue #141