### PR TITLE
Don't use the python root logger...

### DIFF
--- a/src/avalara/ava_logger.py
+++ b/src/avalara/ava_logger.py
@@ -18,7 +18,7 @@ def ava_log(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        logger = logging.getLogger()
+        logger = logging.getLogger("avalara")
         is_log_req_resp_allowed = False
         ava_log_entry = {}
         is_error_log = False


### PR DESCRIPTION
Use an avalara-specific logger.
This allows clients to control whether they want avalara logs to be displayed or propagated to their logging system, and at what levels.