### PR TITLE
build and publish wheels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools
+        pip install build
     - name: Build script
-      run: python3 setup.py sdist
+      run: python3 -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish a wheel as well as a source distribution.